### PR TITLE
Fixed Release Drafter Duplicate Drafts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,13 +1,13 @@
 name: Release Drafter
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [closed]
+    branches: [main]
 
 jobs:
   update_release_draft:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Trigger on merged PR only, not push+PR close. Prevents duplicate draft releases.