### PR TITLE
Added New REST API Endpoints from Schulnetz Web App Analysis

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -46,13 +46,17 @@ def _flatten_any_of_nullable(obj):
             types = obj["anyOf"]
             null_type = next((t for t in types if t.get("type") == "null"), None)
             real_type = next((t for t in types if t.get("type") != "null"), None)
-            if null_type and real_type and "type" in real_type:
+            if null_type and real_type:
                 obj.pop("anyOf")
-                obj["type"] = real_type["type"]
-                obj["nullable"] = True
-                for k, v in real_type.items():
-                    if k != "type":
-                        obj[k] = v
+                if "$ref" in real_type:
+                    obj["$ref"] = real_type["$ref"]
+                    obj["nullable"] = True
+                elif "type" in real_type:
+                    obj["type"] = real_type["type"]
+                    obj["nullable"] = True
+                    for k, v in real_type.items():
+                        if k != "type":
+                            obj[k] = v
                 return obj
         for v in obj.values():
             _flatten_any_of_nullable(v)

--- a/src/api/controllers/mobile_proxy_controller.py
+++ b/src/api/controllers/mobile_proxy_controller.py
@@ -7,12 +7,14 @@ from src.application.dtos.mobile.topic_dto import TopicDto
 from src.application.dtos.mobile.notification_dto import NotificationDto
 from src.application.dtos.mobile.grade_dto import GradeDto
 from src.application.dtos.mobile.exam_dto import ExamDto
+from src.application.dtos.mobile.event_dto import EventDto
+from src.application.dtos.mobile.absence_dto import AbsenceDto
 from src.application.dtos.mobile.absencenotice_dto import AbsenceNoticeDto
 from src.application.dtos.mobile.absencenoticestatus_dto import AbsenceNoticeStatusDto
-from src.application.dtos.mobile.absence_dto import AbsenceDto
-from src.application.dtos.mobile.agenda_dto import AgendaDto
 from src.application.dtos.mobile.setting_dto import SettingDto
 from src.application.dtos.mobile.user_info_dto import UserInfoDto
+from src.application.dtos.mobile.vacation_dto import VacationDto
+from src.application.dtos.mobile.homework_dto import HomeworkDto, ObjectiveDto
 from src.application.queries.proxy_mobile_rest_query import proxy_mobile_rest_query_async
 from src.api.auth.token_dependency import get_current_token
 from src.api.auth.bearer import security
@@ -20,53 +22,123 @@ from src.api.router_registry import SchulwareAPIRouter
 
 router = SchulwareAPIRouter()
 
+
+# === User Info ===
+
 @router.get("userInfo", dependencies=[Depends(security)], response_model=UserInfoDto)
-async def get_mobile_user_info(token: str = Depends(get_current_token)):
+async def get_user_info(token: str = Depends(get_current_token)):
     return await proxy_mobile_rest_query_async(token, "me", "GET")
 
-@router.get("settings", dependencies=[Depends(security)], response_model=list[SettingDto])
-async def get_mobile_settings(token: str = Depends(get_current_token)):
-    return await proxy_mobile_rest_query_async(token, "config/settings", "GET")
 
-@router.get("agenda", dependencies=[Depends(security)], response_model=list[AgendaDto])
-async def get_mobile_events(token: str = Depends(get_current_token), min_date: Optional[str] = Query(None), max_date: Optional[str] = Query(None)):
+# === Grades ===
+
+@router.get("grades", dependencies=[Depends(security)], response_model=list[GradeDto])
+async def get_grades(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "me/grades", "GET")
+
+
+# === Events / Timetable ===
+
+@router.get("events", dependencies=[Depends(security)], response_model=list[EventDto])
+async def get_events(
+    token: str = Depends(get_current_token),
+    min_date: Optional[str] = Query(None),
+    max_date: Optional[str] = Query(None),
+):
     query_params = [("min_date", min_date), ("max_date", max_date)]
     return await proxy_mobile_rest_query_async(token, "me/events", "GET", query_params=query_params)
 
+@router.get("agenda", dependencies=[Depends(security)], response_model=list[EventDto])
+async def get_agenda(
+    token: str = Depends(get_current_token),
+    min_date: Optional[str] = Query(None),
+    max_date: Optional[str] = Query(None),
+):
+    query_params = [("min_date", min_date), ("max_date", max_date)]
+    return await proxy_mobile_rest_query_async(token, "me/events", "GET", query_params=query_params)
+
+
+# === Exams ===
+
+@router.get("exams", dependencies=[Depends(security)], response_model=list[ExamDto])
+async def get_exams(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "me/exams", "GET")
+
+
+# === Absences ===
+
 @router.get("absences", dependencies=[Depends(security)], response_model=list[AbsenceDto])
-async def get_mobile_absences(token: str = Depends(get_current_token)):
+async def get_absences(token: str = Depends(get_current_token)):
     return await proxy_mobile_rest_query_async(token, "me/absences", "GET")
 
 @router.get("absencenotices", dependencies=[Depends(security)], response_model=list[AbsenceNoticeDto])
-async def get_mobile_absence_notices(token: str = Depends(get_current_token)):
+async def get_absence_notices(token: str = Depends(get_current_token)):
     return await proxy_mobile_rest_query_async(token, "me/absencenotices", "GET")
 
 @router.get("absencenoticestatus", dependencies=[Depends(security)], response_model=list[AbsenceNoticeStatusDto])
-async def get_mobile_absence_notice_status( token: str = Depends(get_current_token)):
+async def get_absence_notice_status(token: str = Depends(get_current_token)):
     return await proxy_mobile_rest_query_async(token, "config/lists/absenceNoticeStatus", "GET")
 
-@router.get("exams", dependencies=[Depends(security)], response_model=list[ExamDto])
-async def get_mobile_exams(token: str = Depends(get_current_token)):
-    return await proxy_mobile_rest_query_async(token, "me/exams", "GET")
+@router.get("absences/confirmed", dependencies=[Depends(security)])
+async def get_absences_confirmed(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "me/absencesAndLateness/isAlreadyConfirmed", "GET")
 
-@router.get("grades", dependencies=[Depends(security)], response_model=list[GradeDto])
-async def get_mobile_grades(token: str = Depends(get_current_token)):
-    return await proxy_mobile_rest_query_async(token, "me/grades", "GET")
+
+# === Lateness ===
+
+@router.get("lateness", dependencies=[Depends(security)], response_model=list[LatenessDto])
+async def get_lateness(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "me/lateness", "GET")
+
+
+# === Vacations ===
+
+@router.get("vacations", dependencies=[Depends(security)], response_model=list[VacationDto])
+async def get_vacations(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "me/vacations", "GET")
+
+
+# === Notes ===
+
+@router.get("homework", dependencies=[Depends(security)], response_model=list[HomeworkDto])
+async def get_homework(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "me/notes/homework", "GET")
+
+@router.get("objectives", dependencies=[Depends(security)], response_model=list[ObjectiveDto])
+async def get_objectives(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "me/notes/objectives", "GET")
+
+
+# === Notifications ===
 
 @router.get("notifications", dependencies=[Depends(security)], response_model=list[NotificationDto])
-async def get_mobile_notifications(token: str = Depends(get_current_token)):
+async def get_notifications(token: str = Depends(get_current_token)):
     return await proxy_mobile_rest_query_async(token, "me/notifications/push", "GET")
 
 @router.get("topics", dependencies=[Depends(security)], response_model=list[TopicDto])
-async def get_mobile_topics(token: str = Depends(get_current_token)):
+async def get_topics(token: str = Depends(get_current_token)):
     return await proxy_mobile_rest_query_async(token, "me/notifications/topics", "GET")
 
-@router.get("lateness", dependencies=[Depends(security)], response_model=list[LatenessDto])
-async def get_mobile_lateness(token: str = Depends(get_current_token)):
-    return await proxy_mobile_rest_query_async(token, "me/lateness", "GET")
+
+# === Config ===
+
+@router.get("settings", dependencies=[Depends(security)], response_model=list[SettingDto])
+async def get_settings(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "config/settings", "GET")
+
+@router.get("customfields", dependencies=[Depends(security)])
+async def get_custom_fields(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "config/customFields", "GET")
+
+@router.get("filecategories", dependencies=[Depends(security)])
+async def get_file_categories(token: str = Depends(get_current_token)):
+    return await proxy_mobile_rest_query_async(token, "config/filestoreCategories", "GET")
+
+
+# === Student ID Card ===
 
 @router.get("studentidcard/{report_id}", dependencies=[Depends(security)], response_model=StudentIdCardDto)
-async def get_mobile_cockpit_report(report_id: int, token: str = Depends(get_current_token)):
+async def get_student_id_card(report_id: int, token: str = Depends(get_current_token)):
     response = await proxy_mobile_rest_query_async(token, f"me/cockpitReport/{report_id}", "GET")
     html_content = response.body.decode("utf-8")
     if html_content.startswith('"') and html_content.endswith('"'):

--- a/src/application/dtos/mobile/event_dto.py
+++ b/src/application/dtos/mobile/event_dto.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel
+from typing import Optional, List
+
+
+class EventDto(BaseModel):
+    id: Optional[str] = None
+    startDate: Optional[str] = None
+    endDate: Optional[str] = None
+    text: Optional[str] = None
+    comment: Optional[str] = None
+    roomToken: Optional[str] = None
+    roomId: Optional[str] = None
+    teachers: Optional[List[str]] = None
+    teacherIds: Optional[List[str]] = None
+    teacherTokens: Optional[List[str]] = None
+    courseId: Optional[str] = None
+    courseToken: Optional[str] = None
+    courseName: Optional[str] = None
+    courseCurriculum: Optional[str] = None
+    status: Optional[str] = None
+    color: Optional[str] = None
+    eventType: Optional[str] = None
+    eventRoomStatus: Optional[str] = None
+    timetableText: Optional[str] = None
+    infoFacilityManagement: Optional[str] = None
+    importset: Optional[str] = None
+    lessons: Optional[str] = None
+    publishToInfoSystem: Optional[str] = None
+    studentNames: Optional[str] = None
+    studentIds: Optional[str] = None
+    client: Optional[str] = None
+    clientname: Optional[str] = None
+    weight: Optional[float] = None
+    absTrackedTimestamp: Optional[str] = None

--- a/src/application/dtos/mobile/homework_dto.py
+++ b/src/application/dtos/mobile/homework_dto.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class HomeworkDto(BaseModel):
+    id: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    dueDate: Optional[str] = None
+    courseId: Optional[str] = None
+    courseName: Optional[str] = None
+    isCompleted: Optional[bool] = None
+
+
+class ObjectiveDto(BaseModel):
+    id: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    date: Optional[str] = None
+    courseId: Optional[str] = None
+    courseName: Optional[str] = None

--- a/src/application/dtos/mobile/vacation_dto.py
+++ b/src/application/dtos/mobile/vacation_dto.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class VacationDto(BaseModel):
+    id: Optional[str] = None
+    dateFrom: Optional[str] = None
+    dateTo: Optional[str] = None
+    reason: Optional[str] = None
+    status: Optional[str] = None
+    comment: Optional[str] = None


### PR DESCRIPTION
## Summary

Analyzed the schulnetz.web.app JavaScript source to discover all REST API endpoints, then tested each one against live Schulnetz BBB.

### New endpoints
- `GET /api/mobile/events` — 170 timetable events (rooms, teachers, schedules) — eliminates need for web scraping
- `GET /api/mobile/agenda` — alias for events
- `GET /api/mobile/vacations` — vacation requests
- `GET /api/mobile/homework` — homework notes
- `GET /api/mobile/objectives` — learning objectives
- `GET /api/mobile/absences/confirmed` — confirmation status
- `GET /api/mobile/customfields` — custom field definitions
- `GET /api/mobile/filecategories` — file store categories

### Key finding
The `/me/events` endpoint returns the full timetable — web scraping is NOT needed for schedule data.

## Test results
All endpoints tested with real access token against schulnetz.bbbaden.ch.