### PR TITLE
Renamed test-app to Auth Test App

### DIFF
--- a/.github/workflows/build-test-app-apk.yml
+++ b/.github/workflows/build-test-app-apk.yml
@@ -40,14 +40,14 @@ jobs:
       - name: Stage APK into test-app/dist/
         run: |
           mkdir -p test-app/dist
-          cp test-app/app/build/outputs/apk/debug/app-debug.apk test-app/dist/SchulwareAPITester-debug.apk
+          cp test-app/app/build/outputs/apk/debug/app-debug.apk test-app/dist/AuthTestApp-debug.apk
           ls -l test-app/dist/
 
       - name: Commit APK back to the repo
         run: |
           git config user.name "PianoNic"
           git config user.email "79938743+PianoNic@users.noreply.github.com"
-          git add test-app/dist/SchulwareAPITester-debug.apk
+          git add test-app/dist/AuthTestApp-debug.apk
           if [ -z "$(git status --porcelain)" ]; then
             echo "APK unchanged."
             exit 0

--- a/test-app/README.md
+++ b/test-app/README.md
@@ -1,4 +1,4 @@
-# SchulwareAPI Tester
+# Auth Test App
 
 Minimal Android app for hand-testing the stateless `/api/authenticate/refresh`
 endpoint. Tracks `context_state` round-trips in `SharedPreferences` so you can
@@ -7,8 +7,8 @@ verify the stateless contract end to end.
 ## Build
 
 CI builds a debug APK on every push to `test-app/**` and commits it to
-[`dist/SchulwareAPITester-debug.apk`](dist/SchulwareAPITester-debug.apk).
-`adb install dist/SchulwareAPITester-debug.apk` and you're done.
+[`dist/AuthTestApp-debug.apk`](dist/AuthTestApp-debug.apk).
+`adb install dist/AuthTestApp-debug.apk` and you're done.
 
 Locally (needs Android SDK + Java 17):
 

--- a/test-app/app/src/main/AndroidManifest.xml
+++ b/test-app/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:label="SchulwareAPI Tester"
+        android:label="@string/app_name"
         android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar"
         android:usesCleartextTraffic="true">
         <activity

--- a/test-app/app/src/main/res/values/strings.xml
+++ b/test-app/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">SchulwareAPI Tester</string>
+    <string name="app_name">Auth Test App</string>
 </resources>

--- a/test-app/settings.gradle.kts
+++ b/test-app/settings.gradle.kts
@@ -12,5 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "SchulwareAPITester"
+rootProject.name = "AuthTestApp"
 include(":app")


### PR DESCRIPTION
Per follow-up request: rename the bundled tester from `SchulwareAPI Tester` → `Auth Test App`. Touches the app label, Gradle project name, README, and CI'd APK filename (`AuthTestApp-debug.apk`).