### PR TITLE
Split /refresh: state-only vs deprecated password fallback

### DIFF
--- a/src/api/controllers/auth_controller.py
+++ b/src/api/controllers/auth_controller.py
@@ -14,6 +14,7 @@ from src.application.dtos.auth_oauth_dtos import (
 from src.application.dtos.refresh_dtos import (
     RefreshTokenRequestDto,
     RefreshTokenResponseDto,
+    RefreshTokenWithCredentialsRequestDto,
 )
 from src.infrastructure.logging_config import get_logger
 
@@ -28,9 +29,47 @@ class AuthController:
     @router.post("/refresh", response_model=RefreshTokenResponseDto)
     @shared_limiter.limit("5/minute")
     async def refresh_token(self, request: Request, body: RefreshTokenRequestDto):
-        """Stateless token + session refresh. Caller provides `context_state` from a
-        prior call and receives an updated `context_state` to persist."""
-        return await self.mediator.send(RefreshTokenCommand(body))
+        """Stateless token + session refresh using a stored browser context.
+
+        Caller provides `context_state` from a prior call and receives an
+        updated `context_state` to persist. No credentials are sent. If the
+        stored context has expired, re-authenticate via
+        `/api/authenticate/oauth/mobile/url`."""
+        return await self.mediator.send(RefreshTokenCommand(
+            schulnetz_base_url=body.schulnetz_base_url,
+            context_state=body.context_state,
+            user_agent=body.user_agent,
+        ))
+
+    @router.post(
+        "/refresh-with-credentials",
+        response_model=RefreshTokenResponseDto,
+        deprecated=True,
+        description=(
+            "## ⚠️ DEPRECATED — DO NOT USE\n\n"
+            "Refreshes tokens by replaying a **full Microsoft SSO login with raw "
+            "credentials** through a headless browser. Provided only as a "
+            "last-resort fallback for the very first refresh after cold-start.\n\n"
+            "**Use `/api/authenticate/refresh` with a stored `context_state` "
+            "for every subsequent call.** Storing the user's password long-term "
+            "to call this endpoint repeatedly defeats the entire stateless "
+            "design and exposes the credentials unnecessarily.\n\n"
+            "Preferred cold-start path: drive the OAuth flow via "
+            "`/api/authenticate/oauth/mobile/url` and capture `context_state` "
+            "from the resulting browser session, then use `/refresh` from "
+            "then on."
+        ),
+    )
+    @shared_limiter.limit("2/minute")
+    async def refresh_with_credentials(
+        self, request: Request, body: RefreshTokenWithCredentialsRequestDto
+    ):
+        return await self.mediator.send(RefreshTokenCommand(
+            schulnetz_base_url=body.schulnetz_base_url,
+            email=body.email,
+            password=body.password,
+            user_agent=body.user_agent,
+        ))
 
     @router.get("/oauth/mobile/url", response_model=MobileOAuthUrlResponseDto)
     @shared_limiter.limit("10/minute")

--- a/src/application/commands/refresh_token_command.py
+++ b/src/application/commands/refresh_token_command.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 
 from mediatorx import ICommand, ICommandHandler
 
-from src.application.dtos.refresh_dtos import RefreshTokenRequestDto, RefreshTokenResponseDto
+from src.application.dtos.refresh_dtos import RefreshTokenResponseDto
 from src.infrastructure.logging_config import get_logger
 
 SCHULNETZ_CLIENT_ID = os.getenv("SCHULNETZ_CLIENT_ID", "ppyybShnMerHdtBQ")
@@ -34,7 +34,11 @@ logger = get_logger("refresh_token_command")
 
 @dataclass
 class RefreshTokenCommand(ICommand[RefreshTokenResponseDto]):
-    request: RefreshTokenRequestDto
+    schulnetz_base_url: str
+    context_state: dict | None = None
+    email: str | None = None
+    password: str | None = None
+    user_agent: str | None = None
 
 
 class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenResponseDto]):
@@ -45,13 +49,12 @@ class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenRespo
     """
 
     async def handle(self, command: RefreshTokenCommand) -> RefreshTokenResponseDto:
-        request = command.request
         async with async_playwright() as pw:
             browser = await pw.chromium.launch(headless=True)
             try:
-                if request.context_state:
-                    cs_cookies = request.context_state.get("cookies", [])
-                    cs_origins = request.context_state.get("origins", [])
+                if command.context_state:
+                    cs_cookies = command.context_state.get("cookies", [])
+                    cs_origins = command.context_state.get("origins", [])
                     domains = sorted({c.get("domain", "") for c in cs_cookies})
                     logger.info(
                         "Refresh: %d cookies across %s, %d localStorage origins",
@@ -59,12 +62,12 @@ class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenRespo
                     )
 
                 ctx_kwargs = {}
-                if request.context_state:
-                    ctx_kwargs["storage_state"] = request.context_state
-                if request.user_agent:
+                if command.context_state:
+                    ctx_kwargs["storage_state"] = command.context_state
+                if command.user_agent:
                     # MS binds session cookies to UA — caller MUST send the same UA the
                     # cookies were captured with, otherwise the SSO replay is rejected.
-                    ctx_kwargs["user_agent"] = request.user_agent
+                    ctx_kwargs["user_agent"] = command.user_agent
                 context = await browser.new_context(**ctx_kwargs)
 
                 page = await context.new_page()
@@ -72,25 +75,25 @@ class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenRespo
                 state: str | None = None
 
                 try:
-                    await page.goto(request.schulnetz_base_url, wait_until="load", timeout=60_000)
+                    await page.goto(command.schulnetz_base_url, wait_until="load", timeout=60_000)
                     current_url = page.url
 
                     # SSO session expired → need credentials to re-auth via Microsoft.
                     if "login.microsoftonline.com" in current_url:
-                        if not request.email or not request.password:
+                        if not command.email or not command.password:
                             return RefreshTokenResponseDto(
                                 success=False,
-                                message="Microsoft SSO session expired. Email and password required for re-authentication.",
+                                message="Microsoft SSO session expired. Re-authenticate via /api/authenticate/oauth/mobile/url.",
                             )
-                        await _perform_microsoft_sso(page, request)
-                        await page.wait_for_url(f"{request.schulnetz_base_url}*", timeout=30_000)
+                        await _perform_microsoft_sso(page, command.email, command.password)
+                        await page.wait_for_url(f"{command.schulnetz_base_url}*", timeout=30_000)
 
                     current_url = page.url
                     code, state = _extract_code_state(current_url)
 
                     # Some Schulnetz instances need a second hit before the code shows up.
                     if not code:
-                        await page.goto(request.schulnetz_base_url, wait_until="load", timeout=30_000)
+                        await page.goto(command.schulnetz_base_url, wait_until="load", timeout=30_000)
                         code, state = _extract_code_state(page.url)
 
                     if not code:
@@ -100,11 +103,11 @@ class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenRespo
                     await page.close()
 
                 # Mobile token exchange via a separate PKCE round-trip.
-                access_token, refresh_token = await _exchange_mobile_tokens(context, request.schulnetz_base_url)
+                access_token, refresh_token = await _exchange_mobile_tokens(context, command.schulnetz_base_url)
 
                 # Capture web session cookies + landing-page params using the original code.
                 session_id, web_user_id, web_trans_id = await _capture_web_session(
-                    request.schulnetz_base_url, code, state
+                    command.schulnetz_base_url, code, state
                 )
 
                 # Snapshot the updated context for the caller to persist.
@@ -129,15 +132,15 @@ class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenRespo
 
 # ---------- internals ----------
 
-async def _perform_microsoft_sso(page, request: RefreshTokenRequestDto) -> None:
+async def _perform_microsoft_sso(page, email: str, password: str) -> None:
     email_input = 'input[type="email"], input[name="loginfmt"]'
     await page.wait_for_selector(email_input, timeout=10_000)
-    await page.fill(email_input, request.email)
+    await page.fill(email_input, email)
     await page.click("#idSIButton9")
 
     password_input = 'input[type="password"], input[name="passwd"]'
     await page.wait_for_selector(password_input, timeout=10_000)
-    await page.fill(password_input, request.password)
+    await page.fill(password_input, password)
     await page.click("#idSIButton9")
 
     # "Stay signed in?" prompt is best-effort.

--- a/src/application/dtos/refresh_dtos.py
+++ b/src/application/dtos/refresh_dtos.py
@@ -1,4 +1,4 @@
-"""DTOs for the stateless token refresh endpoint.
+"""DTOs for the stateless token refresh endpoints.
 
 The caller (e.g. the Schuly Schulware plugin) owns persistence of context_state
 and credentials. SchulwareAPI accepts state in, drives Playwright, returns the
@@ -9,14 +9,31 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 class RefreshTokenRequestDto(BaseModel):
+    """Stateless refresh using a previously captured browser context.
+
+    This is the recommended refresh path. No credentials are sent — the request
+    succeeds only if the supplied `context_state` is still valid. When it
+    expires, re-authenticate via `/api/authenticate/oauth/mobile/url` rather
+    than reaching for the deprecated credentials endpoint.
+    """
     schulnetz_base_url: str = Field(..., description="The Schulnetz instance base URL, e.g. https://schulnetz.example.ch")
-    context_state: dict[str, Any] | None = Field(
-        default=None,
-        description="Browser context state (cookies + localStorage) from a previous successful refresh. None on first call.",
+    context_state: dict[str, Any] = Field(
+        ...,
+        description="Browser context state (cookies + localStorage) from a previous successful refresh or OAuth capture.",
     )
-    email: str | None = Field(default=None, description="Required only when context_state is missing/expired and Microsoft SSO must be performed.")
-    password: str | None = Field(default=None, description="Required only when context_state is missing/expired and Microsoft SSO must be performed.")
     user_agent: str | None = Field(default=None, description="UA string to replay with. Microsoft binds session cookies to UA; mismatch invalidates the session.")
+
+class RefreshTokenWithCredentialsRequestDto(BaseModel):
+    """⚠️ DEPRECATED. Refresh by replaying full Microsoft SSO with credentials.
+
+    Provided only as a last-resort fallback for the very first refresh after
+    cold-start. Use `/api/authenticate/refresh` with a stored `context_state`
+    for every subsequent call.
+    """
+    schulnetz_base_url: str = Field(..., description="The Schulnetz instance base URL, e.g. https://schulnetz.example.ch")
+    email: str = Field(..., description="Microsoft SSO email.")
+    password: str = Field(..., description="Microsoft SSO password.")
+    user_agent: str | None = Field(default=None, description="UA string to use for the new session.")
 
 class RefreshTokenResponseDto(BaseModel):
     success: bool


### PR DESCRIPTION
Closes #117

## Summary
- **`POST /api/authenticate/refresh`** — now takes only `schulnetz_base_url`, `context_state` (required), and `user_agent`. No credentials accepted. If the stored context is expired, returns an error pointing the caller at the OAuth flow.
- **`POST /api/authenticate/refresh-with-credentials`** — new, marked `deprecated=True`, takes only `schulnetz_base_url`, `email`, `password`, `user_agent`. Drives a full Microsoft SSO replay. The OpenAPI description carries a prominent ⚠️ DO-NOT-USE warning telling callers to use `/refresh` + the OAuth flow instead.
- `RefreshTokenCommand` flattened to carry all fields directly; controllers build it from whichever DTO they accept.
- Rate limit on the deprecated endpoint tightened to 2/minute (vs 5/minute on the clean one) to discourage misuse.

## Breaking change
Yes — callers that previously sent `email`/`password` in the body of `/refresh` will now get a 422 validation error. They must either:
- switch to OAuth + `/refresh` (recommended), or
- temporarily move to `/refresh-with-credentials` (deprecated).

## Test plan
- [ ] `POST /refresh` with valid `context_state` → success, returns updated state
- [ ] `POST /refresh` with expired `context_state` → success: false with "re-authenticate via /api/authenticate/oauth/mobile/url" message
- [ ] `POST /refresh` with `email`/`password` in body → 422 (fields not accepted)
- [ ] `POST /refresh-with-credentials` with valid creds → success, returns tokens + context_state
- [ ] Swagger shows the credentials endpoint with strikethrough + the DO-NOT-USE description