### PR TITLE
Spike #121: offline_access scope + direct refresh_token grant POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # Playwright MCP debug captures
 .playwright-mcp/
 
+# Scratch / local-only checkouts (e.g. cloned reference repos)
+_tmp/
+
 # C extensions
 *.so
 

--- a/src/api/auth/auth.py
+++ b/src/api/auth/auth.py
@@ -47,7 +47,12 @@ def generate_auth_params(state: str, code_challenge: str, nonce: str) -> dict[st
         "client_id": SCHULNETZ_CLIENT_ID,
         "state": state,
         "redirect_uri": "",  # Empty as shown in curl commands
-        "scope": "openid ",  # Note the trailing space as in curl
+        # SPIKE (#121): requesting `offline_access` to find out whether Schulnetz
+        # will issue a long-lived refresh_token that can be redeemed via the
+        # `grant_type=refresh_token` flow at /token.php — which would let us
+        # skip Playwright for token refreshes entirely. The original value here
+        # was "openid " (trailing space, matching the captured curl).
+        "scope": "openid offline_access",
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
         "nonce": nonce
@@ -1308,7 +1313,8 @@ def generate_oauth_url(base_url: str, auth_type: str = "mobile", redirect_uri: s
         "client_id": SCHULNETZ_CLIENT_ID,
         "state": state,
         "redirect_uri": redirect_uri,
-        "scope": "openid ",  # trailing space matches the original Schulnetz flow
+        # SPIKE (#121): see comment at the other call site. Originally "openid ".
+        "scope": "openid offline_access",
         "nonce": nonce,
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",

--- a/src/api/controllers/auth_controller.py
+++ b/src/api/controllers/auth_controller.py
@@ -6,12 +6,15 @@ from src.api.controller import controller
 from src.api.dependencies import get_mediator, get_schulnetz_base_url
 from src.api.rate_limit import shared_limiter
 from src.application.commands.refresh_token_command import RefreshTokenCommand
+from src.application.commands.refresh_token_grant_command import RefreshTokenGrantCommand
 from src.application.dtos.auth_oauth_dtos import (
     MobileCallbackRequestDto,
     MobileCallbackResponseDto,
     MobileOAuthUrlResponseDto,
 )
 from src.application.dtos.refresh_dtos import (
+    RefreshTokenGrantRequestDto,
+    RefreshTokenGrantResponseDto,
     RefreshTokenRequestDto,
     RefreshTokenResponseDto,
     RefreshTokenWithCredentialsRequestDto,
@@ -39,6 +42,37 @@ class AuthController:
             schulnetz_base_url=body.schulnetz_base_url,
             context_state=body.context_state,
             user_agent=body.user_agent,
+        ))
+
+    @router.post(
+        "/refresh-token",
+        response_model=RefreshTokenGrantResponseDto,
+        description=(
+            "## ⚗️ EXPERIMENTAL — spike for [#121]"
+            "(https://github.com/PianoNic/SchulwareAPI/issues/121)\n\n"
+            "Direct OAuth2 **refresh_token grant** against `/token.php` — no "
+            "Playwright, no Chromium, milliseconds per call. If Schulnetz "
+            "honours this grant, it becomes the preferred refresh path and "
+            "`/refresh` (context_state replay) only stays around as a "
+            "fallback.\n\n"
+            "**Requires** a `refresh_token` from an authorization flow that "
+            "included the `offline_access` scope. This branch enables that "
+            "scope at every OAuth call site, so any token captured after "
+            "deploying it qualifies.\n\n"
+            "**Do not rely on this in production yet** — it's here to be "
+            "tested. The response includes the raw `/token.php` body in "
+            "`raw_response` so you can inspect exactly what Schulnetz returns."
+        ),
+    )
+    @shared_limiter.limit("10/minute")
+    async def refresh_with_grant(
+        self,
+        request: Request,
+        body: RefreshTokenGrantRequestDto,
+    ):
+        return await self.mediator.send(RefreshTokenGrantCommand(
+            schulnetz_base_url=body.schulnetz_base_url.rstrip("/"),
+            refresh_token=body.refresh_token,
         ))
 
     @router.post(

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -16,6 +16,10 @@ from src.application.commands.refresh_token_command import (
     RefreshTokenCommand,
     RefreshTokenHandler,
 )
+from src.application.commands.refresh_token_grant_command import (
+    RefreshTokenGrantCommand,
+    RefreshTokenGrantHandler,
+)
 from src.application.queries.get_app_info_query import (
     GetAppInfoQuery,
     GetAppInfoHandler,
@@ -59,6 +63,7 @@ def build_mediator() -> Mediator:
     # Commands
     m.register(CaptureWebSessionCommand, CaptureWebSessionHandler)
     m.register(RefreshTokenCommand, RefreshTokenHandler)
+    m.register(RefreshTokenGrantCommand, RefreshTokenGrantHandler)
 
     # Queries
     m.register(GetAppInfoQuery, GetAppInfoHandler)

--- a/src/application/commands/refresh_token_command.py
+++ b/src/application/commands/refresh_token_command.py
@@ -168,7 +168,8 @@ async def _exchange_mobile_tokens(context, schulnetz_base_url: str) -> tuple[str
         "client_id": SCHULNETZ_CLIENT_ID,
         "state": secrets.token_hex(16),
         "redirect_uri": "",
-        "scope": "openid ",
+        # SPIKE (#121): added offline_access — see auth.py for rationale.
+        "scope": "openid offline_access",
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
         "nonce": secrets.token_hex(16),

--- a/src/application/commands/refresh_token_grant_command.py
+++ b/src/application/commands/refresh_token_grant_command.py
@@ -1,0 +1,98 @@
+"""⚗️ EXPERIMENTAL (#121) — direct OAuth2 refresh_token grant against /token.php.
+
+Goal of the spike: find out whether Schulnetz issues — and honours — a real
+refresh_token when the original authorization flow includes the
+`offline_access` scope. If so, every routine token refresh can be a single
+HTTP POST instead of a full Playwright/Chromium replay of the captured
+browser context.
+
+How to evaluate the results:
+
+    1. Complete a fresh OAuth flow on this branch (the scope now includes
+       offline_access). Capture the refresh_token from the /token.php
+       response in /api/authenticate/oauth/mobile/callback.
+    2. POST to /api/authenticate/refresh-token with
+       { schulnetz_base_url, refresh_token }.
+    3. Inspect the response:
+         - 200 + new access_token  → grant works. Spike succeeds.
+                                     Promote endpoint to non-experimental,
+                                     make offline_access permanent, document
+                                     refresh layering in the README.
+         - status_code 400 + error="invalid_grant"
+                                   → Schulnetz issued a placeholder token.
+                                     Spike fails for this instance. Keep
+                                     context_state as the only refresh path.
+         - status_code 400 + error="unsupported_grant_type" / 401 / 404
+                                   → Server doesn't expose the grant at all.
+                                     Close #121 as won't-implement.
+    4. Repeat against a second instance once #119 lands (e.g. one of the
+       Solothurn schools) — OAuth servers can be configured differently
+       per deployment.
+"""
+
+from dataclasses import dataclass
+
+import httpx
+from mediatorx import ICommand, ICommandHandler
+
+from src.application.commands.refresh_token_command import SCHULNETZ_CLIENT_ID
+from src.application.dtos.refresh_dtos import RefreshTokenGrantResponseDto
+from src.infrastructure.logging_config import get_logger
+
+logger = get_logger("refresh_token_grant_command")
+
+
+@dataclass
+class RefreshTokenGrantCommand(ICommand[RefreshTokenGrantResponseDto]):
+    schulnetz_base_url: str
+    refresh_token: str
+
+
+class RefreshTokenGrantHandler(ICommandHandler[RefreshTokenGrantCommand, RefreshTokenGrantResponseDto]):
+    async def handle(self, command: RefreshTokenGrantCommand) -> RefreshTokenGrantResponseDto:
+        token_url = f"{command.schulnetz_base_url.rstrip('/')}/token.php"
+
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": command.refresh_token,
+            "client_id": SCHULNETZ_CLIENT_ID,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                response = await client.post(
+                    token_url,
+                    data=payload,
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
+        except httpx.RequestError as e:
+            logger.error("refresh_token grant network error: %s", e)
+            return RefreshTokenGrantResponseDto(
+                success=False,
+                status_code=0,
+                message=f"Network error contacting {token_url}: {e}",
+            )
+
+        try:
+            body = response.json()
+        except ValueError:
+            body = {"_non_json_body": response.text[:500]}
+
+        logger.info(
+            "Spike #121 refresh_token grant: %s %s -> %d, keys=%s",
+            "POST", token_url, response.status_code, sorted(body.keys()) if isinstance(body, dict) else "non-dict",
+        )
+
+        ok = response.status_code == 200 and isinstance(body, dict) and "access_token" in body
+
+        return RefreshTokenGrantResponseDto(
+            success=ok,
+            status_code=response.status_code,
+            access_token=body.get("access_token") if isinstance(body, dict) else None,
+            refresh_token=body.get("refresh_token") if isinstance(body, dict) else None,
+            expires_in=body.get("expires_in") if isinstance(body, dict) else None,
+            token_type=body.get("token_type") if isinstance(body, dict) else None,
+            scope=body.get("scope") if isinstance(body, dict) else None,
+            raw_response=body if isinstance(body, dict) else None,
+            message=None if ok else f"Schulnetz rejected the refresh_token grant ({response.status_code}).",
+        )

--- a/src/application/dtos/refresh_dtos.py
+++ b/src/application/dtos/refresh_dtos.py
@@ -35,6 +35,37 @@ class RefreshTokenWithCredentialsRequestDto(BaseModel):
     password: str = Field(..., description="Microsoft SSO password.")
     user_agent: str | None = Field(default=None, description="UA string to use for the new session.")
 
+class RefreshTokenGrantRequestDto(BaseModel):
+    """⚗️ EXPERIMENTAL (#121). Direct OAuth2 refresh_token grant — no browser.
+
+    Submits `grant_type=refresh_token` to `{schulnetz_base_url}/token.php` with
+    the supplied `refresh_token`. If Schulnetz honours the grant, this becomes
+    the cheapest refresh path (milliseconds, no Chromium) and `/refresh`
+    (context_state replay) only stays around as a fallback.
+
+    The refresh_token must come from an authorization flow that included the
+    `offline_access` scope. With the spike merged, every new OAuth round-trip
+    automatically requests it.
+    """
+    schulnetz_base_url: str = Field(..., description="The Schulnetz instance base URL.")
+    refresh_token: str = Field(..., description="The refresh_token previously issued by /token.php.")
+
+class RefreshTokenGrantResponseDto(BaseModel):
+    """Raw response from /token.php for the refresh_token grant.
+
+    Fields are passed through verbatim so the spike can observe exactly what
+    Schulnetz returns — including any non-standard fields or error shapes.
+    """
+    success: bool
+    status_code: int = Field(..., description="HTTP status code from /token.php — non-200 means the grant was rejected.")
+    access_token: str | None = None
+    refresh_token: str | None = Field(default=None, description="A new refresh_token if Schulnetz rotates them; otherwise null.")
+    expires_in: int | None = None
+    token_type: str | None = None
+    scope: str | None = None
+    raw_response: dict[str, Any] | None = Field(default=None, description="Full /token.php JSON body, for spike inspection.")
+    message: str | None = None
+
 class RefreshTokenResponseDto(BaseModel):
     success: bool
     access_token: str | None = None


### PR DESCRIPTION
Tracks #121

> ⚗️ **DRAFT — DO NOT MERGE until the live test passes.** This branch exists so you can `git checkout` it, run the server against a real Schulnetz instance, and observe whether `/token.php` honours `grant_type=refresh_token`.

## What this branch does

Three small, mechanical, reversible changes:

1. Adds `offline_access` to the OAuth `scope` at all three call sites (each marked with an inline `SPIKE (#121)` comment so reverting is a one-grep job).
2. Adds `POST /api/authenticate/refresh-token` — posts `grant_type=refresh_token` to `{base}/token.php` and returns whatever Schulnetz responds with, including the full raw JSON in `raw_response` for inspection.
3. Logs `status + top-level keys` of the `/token.php` response at INFO so the spike outcome is obvious in dev logs.

Nothing existing is touched. `/refresh` (context_state) and `/refresh-with-credentials` keep working exactly as before.

## How to evaluate

```bash
git fetch && git checkout feature/121_OfflineAccessRefreshTokenSpike
python asgi.py
```

1. **Capture a fresh refresh_token.** Run a full OAuth flow against `https://schulnetz.bbbaden.ch` (or any other instance you have credentials for) via `/api/authenticate/oauth/mobile/url` → `/api/authenticate/oauth/mobile/callback`. The scope is now `openid offline_access`, so a real `refresh_token` should come back.
2. **Try to redeem it.** POST to `/api/authenticate/refresh-token`:

   ```http
   POST /api/authenticate/refresh-token
   X-Schulnetz-Base-Url: https://schulnetz.bbbaden.ch
   Content-Type: application/json

   { "schulnetz_base_url": "https://schulnetz.bbbaden.ch",
     "refresh_token": "<the token from step 1>" }
   ```

3. **Read the response.**

   | Outcome | Meaning | Next step |
   |---|---|---|
   | `200` with `success=true` + `access_token` | 🎉 Grant works. | Promote the endpoint to non-experimental, make `offline_access` permanent, document refresh layering, close #121 as done. |
   | `status_code=400` + `error=invalid_grant` in `raw_response` | Schulnetz issued a placeholder refresh_token that it won't redeem. | Revert this branch. Keep `context_state` as the only real refresh. Close #121 as won't-fix and document the finding. |
   | `status_code=400` + `error=unsupported_grant_type` / `404` / `401` | The grant isn't exposed by this instance at all. | Same — revert + document. |
   | Anything else | Inspect `raw_response` and decide. | — |

4. **Repeat once #119 lands** against a Solothurn school (e.g. KSSO) — OAuth servers can be configured differently per deployment, so we want at least two data points before declaring it works in general.

## If results are negative

Revert is mechanical: `git revert` this commit, or just delete the three `SPIKE (#121)` comments and the new endpoint files. No other code depends on the new endpoint.

## If results are positive

Follow-up tasks (would become a separate PR):

- Drop the experimental warning from the endpoint description.
- Update `RefreshTokenGrantResponseDto` to remove `raw_response` (debug only).
- Document the refresh layering in README + FastAPI description:
  1. `/refresh-token` — preferred (no browser)
  2. `/refresh` — fallback (context_state replay)
  3. `/refresh-with-credentials` — deprecated last resort
- Remove the `SPIKE (#121)` comments since `offline_access` is now permanent.

## Risk

Almost none. The scope change might cause some Schulnetz instances to reject the auth URL outright — if you see authorization failures during step 1 above, the spike still failed, just earlier. Revert and move on.