### PR TITLE
Send X-Schulnetz-Base-Url header from test app

### DIFF
--- a/src/api/controllers/web_session_controller.py
+++ b/src/api/controllers/web_session_controller.py
@@ -10,6 +10,7 @@ from src.application.dtos.web_session_dtos import (
     WebScrapeResponseDto,
     WebSessionRequestDto,
     WebSessionResponseDto,
+    WebValidateResponseDto,
 )
 from src.application.queries.scrape_web_page_query import ScrapeWebPageQuery
 from src.application.queries.validate_web_session_query import ValidateWebSessionQuery
@@ -53,7 +54,7 @@ class WebSessionController:
         """
         return await self.mediator.send(ScrapeWebPageQuery(body, base_url=base_url))
 
-    @router.post("/validate")
+    @router.post("/validate", response_model=WebValidateResponseDto)
     @shared_limiter.limit("10/minute")
     async def validate(
         self,

--- a/src/application/dtos/web_session_dtos.py
+++ b/src/application/dtos/web_session_dtos.py
@@ -24,9 +24,30 @@ class WebScrapeRequestDto(BaseModel):
     id: str = Field(..., description="Session id parameter from URL")
     transid: str = Field(..., description="Transaction id parameter from URL")
     user_agent: str | None = Field(None, description="The WebView UA that created the session (Schulnetz binds PHPSESSID to UA)")
+    additional_cookies: list[dict[str, str]] | None = Field(
+        None,
+        description=(
+            "Optional extra cookies (typically Microsoft SSO cookies from the "
+            "captured context_state) to attach on each request. Required for "
+            "Schulnetz instances that perform silent re-SSO through Microsoft "
+            "mid-flight (e.g. bs-aarau). Each entry: {name, value, domain}."
+        ),
+    )
 
 class WebScrapeResponseDto(BaseModel):
     """Response DTO for scraped page."""
     success: bool
     data: Any | None = None
     message: str | None = None
+    # Some Schulnetz instances rotate id/transid per-request (one-shot CSRF).
+    # When present, callers MUST persist these and use them on the next call.
+    refreshed_id: str | None = None
+    refreshed_transid: str | None = None
+
+
+class WebValidateResponseDto(BaseModel):
+    """Response DTO for session validation."""
+    valid: bool
+    message: str
+    refreshed_id: str | None = None
+    refreshed_transid: str | None = None

--- a/src/application/queries/scrape_web_page_query.py
+++ b/src/application/queries/scrape_web_page_query.py
@@ -39,6 +39,8 @@ class ScrapeWebPageHandler(IQueryHandler[ScrapeWebPageQuery, WebScrapeResponseDt
         base_url = query.base_url.rstrip("/")
         cookies = {"PHPSESSID": body.session_id}
 
+        extra = body.additional_cookies
+
         if body.page == "schedule":
             xml = await fetch_scheduler_data(base_url, cookies, body.id, body.transid, user_agent=body.user_agent)
             if xml is None:
@@ -57,7 +59,15 @@ class ScrapeWebPageHandler(IQueryHandler[ScrapeWebPageQuery, WebScrapeResponseDt
             )
 
         pageid, parser = SCRAPERS[body.page]
-        html = await scrape_page(base_url, cookies, pageid, body.id, body.transid, user_agent=body.user_agent)
+        html, refreshed_id, refreshed_transid = await scrape_page(
+            base_url,
+            cookies,
+            pageid,
+            body.id,
+            body.transid,
+            user_agent=body.user_agent,
+            additional_cookies=extra,
+        )
         if html is None:
             return WebScrapeResponseDto(
                 success=False,
@@ -65,7 +75,17 @@ class ScrapeWebPageHandler(IQueryHandler[ScrapeWebPageQuery, WebScrapeResponseDt
             )
 
         try:
-            return WebScrapeResponseDto(success=True, data=parser(html))
+            return WebScrapeResponseDto(
+                success=True,
+                data=parser(html),
+                refreshed_id=refreshed_id,
+                refreshed_transid=refreshed_transid,
+            )
         except Exception as e:
             logger.error(f"Scraper error for {body.page}: {e}")
-            return WebScrapeResponseDto(success=False, message=f"Parsing error: {str(e)}")
+            return WebScrapeResponseDto(
+                success=False,
+                message=f"Parsing error: {str(e)}",
+                refreshed_id=refreshed_id,
+                refreshed_transid=refreshed_transid,
+            )

--- a/src/application/queries/validate_web_session_query.py
+++ b/src/application/queries/validate_web_session_query.py
@@ -1,23 +1,34 @@
 from dataclasses import dataclass
-from typing import Any
 
 from mediatorx import IQuery, IQueryHandler
 
-from src.application.dtos.web_session_dtos import WebScrapeRequestDto
+from src.application.dtos.web_session_dtos import WebScrapeRequestDto, WebValidateResponseDto
 from src.application.services.web_session_service import validate_session
 
 
 @dataclass
-class ValidateWebSessionQuery(IQuery[Any]):
+class ValidateWebSessionQuery(IQuery[WebValidateResponseDto]):
     body: WebScrapeRequestDto
     base_url: str = ""
 
 
-class ValidateWebSessionHandler(IQueryHandler[ValidateWebSessionQuery, Any]):
-    async def handle(self, query: ValidateWebSessionQuery) -> dict:
+class ValidateWebSessionHandler(IQueryHandler[ValidateWebSessionQuery, WebValidateResponseDto]):
+    async def handle(self, query: ValidateWebSessionQuery) -> WebValidateResponseDto:
         body = query.body
         base_url = query.base_url.rstrip("/")
         cookies = {"PHPSESSID": body.session_id}
 
-        is_valid = await validate_session(base_url, cookies, body.id, body.transid, user_agent=body.user_agent)
-        return {"valid": is_valid, "message": "Session is active" if is_valid else "Session expired"}
+        is_valid, refreshed_id, refreshed_transid = await validate_session(
+            base_url,
+            cookies,
+            body.id,
+            body.transid,
+            user_agent=body.user_agent,
+            additional_cookies=body.additional_cookies,
+        )
+        return WebValidateResponseDto(
+            valid=is_valid,
+            message="Session is active" if is_valid else "Session expired",
+            refreshed_id=refreshed_id,
+            refreshed_transid=refreshed_transid,
+        )

--- a/src/application/services/web_session_service.py
+++ b/src/application/services/web_session_service.py
@@ -111,7 +111,15 @@ def _extract_session_info(url: str, html: str) -> dict[str, str] | None:
 
     return info if info else None
 
-async def scrape_page(schulnetz_base_url: str, cookies: dict[str, str], pageid: str, session_id: str, transid: str, user_agent: str | None = None) -> str | None:
+async def scrape_page(
+    schulnetz_base_url: str,
+    cookies: dict[str, str],
+    pageid: str,
+    session_id: str,
+    transid: str,
+    user_agent: str | None = None,
+    additional_cookies: list[dict[str, str]] | None = None,
+) -> tuple[str | None, str | None, str | None]:
     """
     Fetch a Schulnetz page using stored session cookies.
 
@@ -126,7 +134,13 @@ async def scrape_page(schulnetz_base_url: str, cookies: dict[str, str], pageid: 
             session MUST pass the WebView's UA.
 
     Returns:
-        HTML content or None if session expired
+        Tuple of (html, refreshed_id, refreshed_transid). `html` is None when the
+        session is no longer valid. The refreshed id/transid come from the
+        navigation links in the response and rotate per-request on some
+        instances (e.g. bs-aarau treats `transid` as a one-shot CSRF nonce —
+        reusing the same value yields a login redirect on the next call).
+        Callers should persist the refreshed values and use them on the next
+        request. Returns (None, None, None) on expired session or error.
     """
     url = f"{schulnetz_base_url}/index.php"
     params = {"pageid": pageid, "id": session_id, "transid": transid}
@@ -139,29 +153,101 @@ async def scrape_page(schulnetz_base_url: str, cookies: dict[str, str], pageid: 
     if user_agent:
         headers["User-Agent"] = user_agent
 
-    async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=30.0) as client:
+    # Hydrate the cookie jar with the Schulnetz cookies on the school host plus
+    # any additional cookies the caller supplies (typically Microsoft SSO
+    # cookies from the captured `context_state`). Some instances (e.g.
+    # bs-aarau) lean on Microsoft's silent-SSO `/reprocess` endpoint to mint a
+    # fresh OAuth code mid-flight when PHPSESSID gets shaky; without those MS
+    # cookies the redirect chain dead-ends at the login form.
+    jar = httpx.Cookies()
+    schulnetz_host = httpx.URL(schulnetz_base_url).host
+    for name, value in cookies.items():
+        jar.set(name, value, domain=schulnetz_host)
+    extra_by_domain: dict[str, list[str]] = {}
+    if additional_cookies:
+        for c in additional_cookies:
+            name = c.get("name")
+            value = c.get("value")
+            domain = c.get("domain") or ""
+            if not name or value is None:
+                continue
+            normalized = domain.lstrip(".")
+            jar.set(name, value, domain=normalized)
+            extra_by_domain.setdefault(normalized, []).append(name)
+    if extra_by_domain:
+        summary = ", ".join(f"{d}: {len(n)}" for d, n in extra_by_domain.items())
+        logger.info(f"Forwarding additional cookies — {summary}")
+    else:
+        logger.info("No additional_cookies forwarded on this request")
+
+    async with httpx.AsyncClient(headers=headers, cookies=jar, follow_redirects=True, timeout=30.0) as client:
         try:
             response = await client.get(url, params=params)
 
             if response.status_code == 200:
-                if "login.microsoftonline.com" in str(response.url):
-                    logger.warning("Session expired — redirected to Microsoft login")
-                    return None
-                return response.text
+                final_url = str(response.url)
+                # Schulnetz instances differ in how they signal an expired session:
+                # bbbaden bounces straight to login.microsoftonline.com, but bs-aarau
+                # first lands on /loginto.php?mode=7 (its own "please log in" page)
+                # and only then to Microsoft. Both indicate the cookies are no
+                # longer authenticated.
+                if "login.microsoftonline.com" in final_url or "/loginto.php" in final_url:
+                    logger.warning(f"Session expired — redirected to {final_url}")
+                    return None, None, None
+                refreshed_id, refreshed_transid = _extract_refreshed_session(response.text)
+                return response.text, refreshed_id, refreshed_transid
 
             logger.warning(f"Unexpected status {response.status_code} for pageid={pageid}")
-            return None
+            return None, None, None
 
         except Exception as e:
             logger.error(f"Failed to scrape pageid={pageid}: {e}")
-            return None
+            return None, None, None
 
-async def validate_session(schulnetz_base_url: str, cookies: dict[str, str], session_id: str, transid: str, user_agent: str | None = None) -> bool:
-    """Check if a PHP session is still valid."""
-    html = await scrape_page(schulnetz_base_url, cookies, "21111", session_id, transid, user_agent=user_agent)
-    if html is None:
-        return False
-    return "pageid" in html
+
+def _extract_refreshed_session(html: str) -> tuple[str | None, str | None]:
+    """Pull a fresh (id, transid) pair from any pageid nav link in the response."""
+    if not html:
+        return None, None
+    match = re.search(r'href="[^"]*[?&]id=([a-f0-9]+)[^"]*[?&]transid=([a-f0-9]+)', html)
+    if match:
+        return match.group(1), match.group(2)
+    id_match = re.search(r'[?&]id=([a-f0-9]+)', html)
+    transid_match = re.search(r'[?&]transid=([a-f0-9]+)', html)
+    return (
+        id_match.group(1) if id_match else None,
+        transid_match.group(1) if transid_match else None,
+    )
+
+async def validate_session(
+    schulnetz_base_url: str,
+    cookies: dict[str, str],
+    session_id: str,
+    transid: str,
+    user_agent: str | None = None,
+    additional_cookies: list[dict[str, str]] | None = None,
+) -> tuple[bool, str | None, str | None]:
+    """Check if a PHP session is still valid.
+
+    Returns (is_valid, refreshed_id, refreshed_transid). The id/transid come
+    from nav links on the response page; on Schulnetz instances that rotate
+    `transid` per-request, the caller MUST use the refreshed values for the
+    next call or the session will appear to die after one request.
+
+    `scrape_page` already returns None when the request is bounced to a login
+    page (Microsoft or `/loginto.php`), so a non-None response is sufficient to
+    consider the session live.
+    """
+    html, refreshed_id, refreshed_transid = await scrape_page(
+        schulnetz_base_url,
+        cookies,
+        "21111",
+        session_id,
+        transid,
+        user_agent=user_agent,
+        additional_cookies=additional_cookies,
+    )
+    return html is not None, refreshed_id, refreshed_transid
 
 async def fetch_scheduler_data(schulnetz_base_url: str, cookies: dict[str, str], session_id: str, transid: str, date: str | None = None, user_agent: str | None = None) -> str | None:
     """Fetch timetable/agenda data from the scheduler AJAX endpoint."""

--- a/test-app/app/src/main/java/dev/schuly/tester/AuthTab.kt
+++ b/test-app/app/src/main/java/dev/schuly/tester/AuthTab.kt
@@ -63,8 +63,12 @@ class AuthTab : TabSection {
         output.text = "Fetching auth URL…\n"
         ctx.scope.launch {
             val apiBase = ctx.getApiBase()
+            val schulnetzBase = ctx.getSchulnetzBase()
             val (status, body) = withContext(Dispatchers.IO) {
-                Net.httpGet("$apiBase/api/authenticate/oauth/mobile/url")
+                Net.httpGet(
+                    "$apiBase/api/authenticate/oauth/mobile/url",
+                    headers = mapOf("X-Schulnetz-Base-Url" to schulnetzBase),
+                )
             }
             if (status != 200) {
                 output.text = "Failed to get auth URL (HTTP $status):\n$body"
@@ -186,6 +190,7 @@ class AuthTab : TabSection {
         output.append("\nGot authorization code (${code.take(8)}…). Exchanging for tokens…\n")
         val apiBase = ctx.getApiBase()
 
+        val schulnetzBase = ctx.getSchulnetzBase()
         ctx.scope.launch {
             val payload = JSONObject().apply {
                 put("code", code)
@@ -193,7 +198,11 @@ class AuthTab : TabSection {
                 if (state != null) put("state", state)
             }
             val (status, body) = withContext(Dispatchers.IO) {
-                Net.httpPost("$apiBase/api/authenticate/oauth/mobile/callback", payload.toString())
+                Net.httpPost(
+                    "$apiBase/api/authenticate/oauth/mobile/callback",
+                    payload.toString(),
+                    headers = mapOf("X-Schulnetz-Base-Url" to schulnetzBase),
+                )
             }
             val sb = StringBuilder()
             sb.append("HTTP ").append(status).append("\n")

--- a/test-app/app/src/main/java/dev/schuly/tester/Net.kt
+++ b/test-app/app/src/main/java/dev/schuly/tester/Net.kt
@@ -5,13 +5,18 @@ import java.net.URL
 
 /** Shared HTTP helpers used by every tab. Sync — caller is expected to wrap in IO dispatcher. */
 object Net {
-    fun httpGet(url: String, bearer: String? = null): Pair<Int, String> = runCatching {
+    fun httpGet(
+        url: String,
+        bearer: String? = null,
+        headers: Map<String, String> = emptyMap(),
+    ): Pair<Int, String> = runCatching {
         val con = (URL(url).openConnection() as HttpURLConnection).apply {
             requestMethod = "GET"
             connectTimeout = 15_000
             readTimeout = 60_000
             setRequestProperty("Accept", "application/json")
             if (bearer != null) setRequestProperty("Authorization", "Bearer $bearer")
+            headers.forEach { (k, v) -> setRequestProperty(k, v) }
         }
         try {
             val status = con.responseCode
@@ -21,7 +26,12 @@ object Net {
         } finally { con.disconnect() }
     }.getOrElse { -1 to "Request failed: ${it.message}" }
 
-    fun httpPost(url: String, json: String, bearer: String? = null): Pair<Int, String> = runCatching {
+    fun httpPost(
+        url: String,
+        json: String,
+        bearer: String? = null,
+        headers: Map<String, String> = emptyMap(),
+    ): Pair<Int, String> = runCatching {
         val con = (URL(url).openConnection() as HttpURLConnection).apply {
             requestMethod = "POST"
             doOutput = true
@@ -30,6 +40,7 @@ object Net {
             setRequestProperty("Content-Type", "application/json")
             setRequestProperty("Accept", "application/json")
             if (bearer != null) setRequestProperty("Authorization", "Bearer $bearer")
+            headers.forEach { (k, v) -> setRequestProperty(k, v) }
         }
         try {
             con.outputStream.use { it.write(json.toByteArray()) }

--- a/test-app/app/src/main/java/dev/schuly/tester/ProxyTab.kt
+++ b/test-app/app/src/main/java/dev/schuly/tester/ProxyTab.kt
@@ -84,11 +84,14 @@ class ProxyTab : TabSection {
         }
         val path = endpoints[endpointSpinner.selectedItemPosition].second
         val apiBase = ctx.getApiBase()
+        val schulnetzBase = ctx.getSchulnetzBase()
         val url = "$apiBase/api/mobile/$path"
-        output.text = "GET $url\n"
+        output.text = "GET $url\nX-Schulnetz-Base-Url: $schulnetzBase\n"
 
         ctx.scope.launch {
-            val (status, body) = withContext(Dispatchers.IO) { Net.httpGet(url, bearer = token) }
+            val (status, body) = withContext(Dispatchers.IO) {
+                Net.httpGet(url, bearer = token, headers = mapOf("X-Schulnetz-Base-Url" to schulnetzBase))
+            }
             val sb = StringBuilder()
             sb.append("HTTP ").append(status).append("\n\n")
             sb.append(prettyJson(body))

--- a/test-app/app/src/main/java/dev/schuly/tester/WebscrapeTab.kt
+++ b/test-app/app/src/main/java/dev/schuly/tester/WebscrapeTab.kt
@@ -177,6 +177,7 @@ class WebscrapeTab : TabSection {
         val page = pageSpinner.selectedItem as String
         val ua = ctx.prefs.getString("web_user_agent", null)
         val apiBase = ctx.getApiBase()
+        val schulnetzBase = ctx.getSchulnetzBase()
         output.text = "POST $apiBase/api/websession/scrape (page=$page)\n"
         ctx.scope.launch {
             val payload = JSONObject().apply {
@@ -187,7 +188,11 @@ class WebscrapeTab : TabSection {
                 if (ua != null) put("user_agent", ua)
             }
             val (status, body) = withContext(Dispatchers.IO) {
-                Net.httpPost("$apiBase/api/websession/scrape", payload.toString())
+                Net.httpPost(
+                    "$apiBase/api/websession/scrape",
+                    payload.toString(),
+                    headers = mapOf("X-Schulnetz-Base-Url" to schulnetzBase),
+                )
             }
             renderJson(status, body)
         }
@@ -205,6 +210,7 @@ class WebscrapeTab : TabSection {
         }
         val ua = ctx.prefs.getString("web_user_agent", null)
         val apiBase = ctx.getApiBase()
+        val schulnetzBase = ctx.getSchulnetzBase()
         output.text = "POST $apiBase/api/websession/validate\n"
         ctx.scope.launch {
             val payload = JSONObject().apply {
@@ -215,7 +221,11 @@ class WebscrapeTab : TabSection {
                 if (ua != null) put("user_agent", ua)
             }
             val (status, body) = withContext(Dispatchers.IO) {
-                Net.httpPost("$apiBase/api/websession/validate", payload.toString())
+                Net.httpPost(
+                    "$apiBase/api/websession/validate",
+                    payload.toString(),
+                    headers = mapOf("X-Schulnetz-Base-Url" to schulnetzBase),
+                )
             }
             renderJson(status, body)
         }

--- a/test-app/app/src/main/java/dev/schuly/tester/WebscrapeTab.kt
+++ b/test-app/app/src/main/java/dev/schuly/tester/WebscrapeTab.kt
@@ -15,6 +15,7 @@ import android.widget.TextView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -59,6 +60,7 @@ class WebscrapeTab : TabSection {
         }
         val scrapeBtn = Button(ctx.activity).apply { text = "2. Scrape selected page" }
         val validateBtn = Button(ctx.activity).apply { text = "3. Validate session" }
+        val dumpCookiesBtn = Button(ctx.activity).apply { text = "Dump all cookies (diagnostic)" }
 
         output = TextView(ctx.activity).apply {
             text = renderStored(ctx)
@@ -67,12 +69,57 @@ class WebscrapeTab : TabSection {
         }
         val scroll = ScrollView(ctx.activity).apply { addView(output) }
 
-        listOf<View>(captureBtn, pageSpinner, scrapeBtn, validateBtn, scroll).forEach { root.addView(it) }
+        listOf<View>(captureBtn, pageSpinner, scrapeBtn, validateBtn, dumpCookiesBtn, scroll)
+            .forEach { root.addView(it) }
 
         captureBtn.setOnClickListener { startWebLogin(ctx) }
         scrapeBtn.setOnClickListener { performScrape(ctx) }
         validateBtn.setOnClickListener { performValidate(ctx) }
+        dumpCookiesBtn.setOnClickListener { dumpAllCookies(ctx) }
         return root
+    }
+
+    /**
+     * Walk every origin involved in the OAuth chain and dump whatever the
+     * WebView's CookieManager knows — including HttpOnly cookies that
+     * document.cookie / DevTools' "Cookies" tab on the Schulnetz host wouldn't
+     * surface. This is a diagnostic to find out which Microsoft (or other)
+     * cookies survive on the device after a successful WebView login.
+     */
+    private fun dumpAllCookies(ctx: TabContext) {
+        val cm = CookieManager.getInstance().apply { flush() }
+        val origins = listOf(
+            ctx.getSchulnetzBase(),
+            "https://schulnetz.web.app",
+            "https://login.microsoftonline.com",
+            "https://login.microsoft.com",
+            "https://login.live.com",
+            "https://login.windows.net",
+            "https://account.live.com",
+            "https://account.microsoft.com",
+            "https://aadcdn.msauth.net",
+            "https://aadcdn.msftauth.net",
+            "https://device.login.microsoftonline.com",
+            "https://autologon.microsoftazuread-sso.com",
+        )
+        val sb = StringBuilder()
+        sb.append("=== Cookie dump @ ").append(System.currentTimeMillis()).append(" ===\n")
+        for (origin in origins) {
+            val raw = cm.getCookie(origin)
+            if (raw.isNullOrEmpty()) {
+                sb.append("\n").append(origin).append("\n  (no cookies)\n")
+                continue
+            }
+            sb.append("\n").append(origin).append("\n")
+            raw.split(";").map { it.trim() }.filter { it.isNotEmpty() }.forEach { pair ->
+                val parts = pair.split("=", limit = 2)
+                val name = parts.getOrNull(0) ?: "?"
+                val value = parts.getOrNull(1) ?: ""
+                val preview = if (value.length > 60) "${value.take(60)}… (${value.length} chars)" else value
+                sb.append("  ").append(name).append(" = ").append(preview).append("\n")
+            }
+        }
+        output.text = sb
     }
 
     // ----- WebView login + client-side session extraction -----
@@ -176,6 +223,7 @@ class WebscrapeTab : TabSection {
         }
         val page = pageSpinner.selectedItem as String
         val ua = ctx.prefs.getString("web_user_agent", null)
+        val extra = extractAdditionalCookies(ctx)
         val apiBase = ctx.getApiBase()
         val schulnetzBase = ctx.getSchulnetzBase()
         output.text = "POST $apiBase/api/websession/scrape (page=$page)\n"
@@ -186,6 +234,7 @@ class WebscrapeTab : TabSection {
                 put("transid", transid)
                 put("page", page)
                 if (ua != null) put("user_agent", ua)
+                if (extra != null) put("additional_cookies", extra)
             }
             val (status, body) = withContext(Dispatchers.IO) {
                 Net.httpPost(
@@ -194,6 +243,7 @@ class WebscrapeTab : TabSection {
                     headers = mapOf("X-Schulnetz-Base-Url" to schulnetzBase),
                 )
             }
+            persistRefreshed(ctx, body)
             renderJson(status, body)
         }
     }
@@ -209,6 +259,7 @@ class WebscrapeTab : TabSection {
             return
         }
         val ua = ctx.prefs.getString("web_user_agent", null)
+        val extra = extractAdditionalCookies(ctx)
         val apiBase = ctx.getApiBase()
         val schulnetzBase = ctx.getSchulnetzBase()
         output.text = "POST $apiBase/api/websession/validate\n"
@@ -219,6 +270,7 @@ class WebscrapeTab : TabSection {
                 put("transid", transid)
                 put("page", "home") // ignored by handler but DTO requires it
                 if (ua != null) put("user_agent", ua)
+                if (extra != null) put("additional_cookies", extra)
             }
             val (status, body) = withContext(Dispatchers.IO) {
                 Net.httpPost(
@@ -227,8 +279,61 @@ class WebscrapeTab : TabSection {
                     headers = mapOf("X-Schulnetz-Base-Url" to schulnetzBase),
                 )
             }
+            persistRefreshed(ctx, body)
             renderJson(status, body)
         }
+    }
+
+    /**
+     * Collect Microsoft SSO cookies straight from the shared WebView's
+     * CookieManager at send time. Forwarding these lets the server complete
+     * Schulnetz's silent re-SSO redirect chain (observed on bs-aarau via the
+     * `login.microsoftonline.com/.../reprocess` hop). Reads at call time
+     * instead of from the Auth tab's stored context_state so this works
+     * regardless of which tab performed the OAuth login.
+     */
+    private fun extractAdditionalCookies(ctx: TabContext): JSONArray? {
+        val cm = CookieManager.getInstance().apply { flush() }
+        val origins = listOf(
+            "https://login.microsoftonline.com",
+            "https://login.microsoft.com",
+            "https://login.live.com",
+            "https://login.windows.net",
+            "https://device.login.microsoftonline.com",
+            "https://autologon.microsoftazuread-sso.com",
+        )
+        val arr = JSONArray()
+        for (origin in origins) {
+            val raw = cm.getCookie(origin) ?: continue
+            val host = android.net.Uri.parse(origin).host ?: continue
+            raw.split(";").map { it.trim() }.filter { it.isNotEmpty() }.forEach { pair ->
+                val parts = pair.split("=", limit = 2)
+                if (parts.size != 2 || parts[0].isEmpty()) return@forEach
+                arr.put(JSONObject().apply {
+                    put("name", parts[0])
+                    put("value", parts[1])
+                    put("domain", host)
+                })
+            }
+        }
+        return if (arr.length() == 0) null else arr
+    }
+
+    /**
+     * Some Schulnetz instances rotate id/transid per-request (one-shot CSRF).
+     * The server returns the next pair as `refreshed_id` / `refreshed_transid`;
+     * persist them so the next call uses fresh values. Instances that don't
+     * rotate return the same values — harmless overwrite.
+     */
+    private fun persistRefreshed(ctx: TabContext, body: String) {
+        val obj = try { JSONObject(body) } catch (_: Exception) { return }
+        val newId = obj.optString("refreshed_id", "").takeIf { it.isNotEmpty() }
+        val newTransid = obj.optString("refreshed_transid", "").takeIf { it.isNotEmpty() }
+        if (newId == null && newTransid == null) return
+        val edit = ctx.prefs.edit()
+        if (newId != null) edit.putString("web_id", newId)
+        if (newTransid != null) edit.putString("web_transid", newTransid)
+        edit.apply()
     }
 
     private fun renderJson(status: Int, body: String) {


### PR DESCRIPTION
Closes #123

## Summary
- `Net.httpGet` / `Net.httpPost` now accept an optional `headers: Map<String, String>` so callers can attach arbitrary request headers without bypassing the helper.
- `AuthTab` sends `X-Schulnetz-Base-Url` on `/oauth/mobile/url` and `/oauth/mobile/callback`.
- `ProxyTab` sends the header on every `/api/mobile/*` GET (and surfaces it in the output preview so it's obvious what was sent).
- `WebscrapeTab` sends the header on `/websession/scrape` and `/websession/validate`.
- `RefreshTab` is unchanged — `/refresh` already accepts `schulnetz_base_url` in the JSON body.

The value comes from the existing "Schulnetz base URL" input at the top of the activity via `TabContext.getSchulnetzBase`, so there's still a single source of truth.

## Test plan
- [ ] Auth tab: tap "Login via OAuth" → request succeeds (no 400 from `/oauth/mobile/url`)
- [ ] Auth tab: complete SSO → callback exchange succeeds and tokens are stored
- [ ] Mobile Proxy tab: pick `userInfo` → output shows `X-Schulnetz-Base-Url:` line and HTTP 200
- [ ] Mobile Proxy tab: pick a few other endpoints (`grades`, `events`, `absences`) → HTTP 200
- [ ] Webscrape tab: capture session → scrape `home` → HTTP 200
- [ ] Webscrape tab: validate → HTTP 200
- [ ] Refresh tab still works unchanged