### PR TITLE
Flatten nullable any-typed fields in OpenAPI schema

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -95,14 +95,13 @@ def _flatten_any_of_nullable(obj):
             types = obj["anyOf"]
             null_type = next((t for t in types if t.get("type") == "null"), None)
             real_type = next((t for t in types if t.get("type") != "null"), None)
-            if null_type and real_type:
+            if null_type and real_type is not None:
                 obj.pop("anyOf")
+                obj["nullable"] = True
                 if "$ref" in real_type:
                     obj["$ref"] = real_type["$ref"]
-                    obj["nullable"] = True
                 elif "type" in real_type:
                     obj["type"] = real_type["type"]
-                    obj["nullable"] = True
                     for k, v in real_type.items():
                         if k != "type":
                             obj[k] = v


### PR DESCRIPTION
## Summary
- Extend the `anyOf: [<T>, {type: null}]` flattener to handle empty-schema variants (`anyOf: [{}, {type: null}]`), producing a plain `{"nullable": true}` so generated clients emit clean nullable fields instead of awkward unions.

Closes #125