### PR TITLE
Scraped all semesters newer than the selected one for grades

### DIFF
--- a/src/application/queries/scrape_web_page_query.py
+++ b/src/application/queries/scrape_web_page_query.py
@@ -48,15 +48,17 @@ async def _scrape_all_semester_grades(
     original = next((sid for sid, _, sel in options if sel), options[0][0])
     fresh = (m.group(1) if (m := _TRANSID_RE.search(html)) else None) or transid
 
-    # The dropdown is newest-first and includes *future* semesters above the
-    # current one (e.g. "2. 35/36"); those are always empty. Start at the
-    # session-selected semester (the current real one) and walk backwards so the
-    # "2 empty in a row" stop condition doesn't trip on future placeholders.
-    selected_idx = next((i for i, (_, _, sel) in enumerate(options) if sel), 0)
-
+    # The dropdown is newest-first: a few (always-empty) *future* placeholder
+    # terms, then the current term, then history. We must NOT start at the
+    # session-selected semester — a session captured in an earlier term stays
+    # pinned there, so the current term (with the student's newest grades) can sit
+    # *above* the selected one and would be missed. Instead walk the whole list:
+    # skip leading empty placeholders without counting them, and once we've seen
+    # real data, stop after two empty terms in a row (the end of history).
     merged: list = []
     empty = 0
-    for sem_id, label, _ in options[selected_idx:]:  # current, then older
+    seen_data = False
+    for sem_id, label, _ in options:
         if not await save_semid(base_url, cookies, session_id, fresh, sem_id, user_agent=user_agent):
             break
         page_html = await scrape_page(base_url, cookies, "21311", session_id, transid, user_agent=user_agent)
@@ -68,10 +70,12 @@ async def _scrape_all_semester_grades(
         if page.courses:
             merged.extend(page.courses)
             empty = 0
-        else:
+            seen_data = True
+        elif seen_data:
             empty += 1
             if empty >= _MAX_EMPTY_SEMESTERS:
                 break
+        # else: leading future placeholder above the current term — keep looking.
 
     # Put the session back on the semester it started on.
     await save_semid(base_url, cookies, session_id, fresh, original, user_agent=user_agent)

--- a/tests/test_grade_semester_scrape.py
+++ b/tests/test_grade_semester_scrape.py
@@ -1,0 +1,49 @@
+"""Regression: the grade scrape must cover semesters NEWER than the session's
+selected one. A session captured in an earlier term stays pinned there, so the
+current term (with the student's newest grades) sits above the selected option
+in the newest-first dropdown and must still be scraped."""
+
+import pytest
+
+from src.application.queries import scrape_web_page_query as q
+from src.application.dtos.web.scrape_dtos import CourseGradesDto, GradesPageDto
+
+
+@pytest.mark.asyncio
+async def test_scrapes_semesters_newer_than_the_selected_one(monkeypatch):
+    # Newest-first dropdown: a future placeholder (empty), the CURRENT term with
+    # the new grades (NOT selected), the session-pinned OLD term, then history.
+    options = [
+        ("99", "2. 35/36", False),  # future placeholder — empty
+        ("41", "2. 25/26", False),  # current term, has the NEW grades, not selected
+        ("40", "1. 25/26", True),   # session is pinned to this older term
+        ("39", "2. 24/25", False),  # older — empty
+        ("38", "1. 24/25", False),  # older — empty (2nd in a row → stop)
+    ]
+    data_by_sem = {
+        "41": [CourseGradesDto(course="Math new", course_token="M", average=5.0, confirmed=False, exams=[])],
+        "40": [CourseGradesDto(course="Math old", course_token="M", average=4.0, confirmed=False, exams=[])],
+    }
+    state = {"sem": "40"}  # the session starts on the old term
+
+    async def fake_save_semid(base, cookies, sid, transid, sem_id, user_agent=None):
+        state["sem"] = sem_id
+        return True
+
+    async def fake_scrape_page(base, cookies, pageid, sid, transid, user_agent=None):
+        return f"<html data-sem='{state['sem']}'></html>"
+
+    def fake_scrape_noten(html):
+        return GradesPageDto(student="Stud", courses=data_by_sem.get(state["sem"], []))
+
+    monkeypatch.setattr(q, "parse_semester_options", lambda html: options)
+    monkeypatch.setattr(q, "save_semid", fake_save_semid)
+    monkeypatch.setattr(q, "scrape_page", fake_scrape_page)
+    monkeypatch.setattr(q, "scrape_noten", fake_scrape_noten)
+
+    result = await q._scrape_all_semester_grades("http://x", {}, "sid", "tid", "ua")
+    names = {c.course for c in result.courses}
+
+    assert "Math new" in names, "current-term grades (newer than selected) were missed"
+    assert "Math old" in names
+    assert state["sem"] == "40", "session must be restored to its original semester"


### PR DESCRIPTION
Scraped all semesters newer than the selected one for grades

Closes #141

The grade scrape started at the session-selected semester and only walked to older terms, so a session pinned to an earlier term never scraped the current term (where the newest grades live). Now walks the whole newest-first dropdown: skips the always-empty leading future placeholders without counting them, and stops after two empty terms in a row once data has been seen. Added a regression test that fails on the old `options[selected_idx:]` behaviour.