### PR TITLE
Fixed the refresh runner minting a dead web session

### DIFF
--- a/src/application/commands/refresh_token_command.py
+++ b/src/application/commands/refresh_token_command.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from mediatorx import ICommand, ICommandHandler
 
 from src.application.dtos.refresh_dtos import RefreshTokenResponseDto
+from src.application.services.web_session_service import capture_web_session
 from src.infrastructure.logging_config import get_logger
 
 SCHULNETZ_CLIENT_ID = os.getenv("SCHULNETZ_CLIENT_ID", "ppyybShnMerHdtBQ")
@@ -71,32 +72,54 @@ class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenRespo
                     ctx_kwargs["user_agent"] = command.user_agent
                 context = await browser.new_context(**ctx_kwargs)
 
+                host = urlparse(command.schulnetz_base_url).netloc
+                captured: dict[str, str | None] = {"code": None, "state": None}
+
+                async def _harvest_code(route):
+                    # Grab the OAuth code off the redirect to Schulnetz, then ABORT it.
+                    # Letting the browser load /?code= makes Schulnetz consume the
+                    # single-use code right there, leaving the later httpx exchange
+                    # with a spent code and a dead PHPSESSID. (Same trick as the
+                    # mobile-token flow in _exchange_mobile_tokens.)
+                    req_url = route.request.url
+                    if "code=" in req_url:
+                        qs = parse_qs(urlparse(req_url).query)
+                        captured["code"] = qs.get("code", [None])[0]
+                        captured["state"] = qs.get("state", [None])[0]
+                        await route.abort()
+                    else:
+                        await route.continue_()
+
                 page = await context.new_page()
+                await page.route(lambda u: host in u, _harvest_code)
                 code: str | None = None
                 state: str | None = None
 
                 try:
-                    await page.goto(command.schulnetz_base_url, wait_until="load", timeout=60_000)
-                    current_url = page.url
+                    try:
+                        await page.goto(command.schulnetz_base_url, wait_until="load", timeout=60_000)
+                    except Exception:
+                        pass  # the post-SSO ?code= redirect is intercepted + aborted
 
-                    # SSO session expired → need credentials to re-auth via Microsoft.
-                    if "login.microsoftonline.com" in current_url:
+                    # Expired MS SSO → need credentials to re-auth via Microsoft.
+                    if not captured["code"] and "login.microsoftonline.com" in page.url:
                         if not command.email or not command.password:
                             return RefreshTokenResponseDto(
                                 success=False,
                                 message="Microsoft SSO session expired. Re-authenticate via /api/authenticate/oauth/mobile/url.",
                             )
-                        await _perform_microsoft_sso(page, command.email, command.password)
-                        await page.wait_for_url(f"{command.schulnetz_base_url}*", timeout=30_000)
+                        try:
+                            await _perform_microsoft_sso(page, command.email, command.password)
+                        except Exception:
+                            pass  # final ?code= redirect is intercepted + aborted
 
-                    current_url = page.url
-                    code, state = _extract_code_state(current_url)
+                    # Let the intercepted redirect settle.
+                    for _ in range(20):
+                        if captured["code"]:
+                            break
+                        await page.wait_for_timeout(500)
 
-                    # Some Schulnetz instances need a second hit before the code shows up.
-                    if not code:
-                        await page.goto(command.schulnetz_base_url, wait_until="load", timeout=30_000)
-                        code, state = _extract_code_state(page.url)
-
+                    code, state = captured["code"], captured["state"]
                     if not code:
                         return RefreshTokenResponseDto(success=False, message="Failed to obtain authorization code")
 
@@ -246,22 +269,13 @@ async def _exchange_mobile_tokens(context, schulnetz_base_url: str) -> tuple[str
 async def _capture_web_session(
     schulnetz_base_url: str, code: str, state: str | None
 ) -> tuple[str | None, str | None, str | None]:
-    async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
-        login_url = f"{schulnetz_base_url}/loginto.php"
-        params = {"code": code, "state": state or "", "mode": "4", "lang": ""}
-        res = await client.get(login_url, params=params)
-
-        cookies: dict[str, str] = {}
-        for resp in res.history + [res]:
-            cookies.update(dict(resp.cookies))
-
-        session_id = cookies.get("PHPSESSID")
-
-        html = res.text
-        id_match = re.search(r"[?&]id=([a-f0-9]{10,})", html)
-        transid_match = re.search(r"[?&]transid=([a-f0-9]+)", html)
-        web_user_id = id_match.group(1) if id_match else None
-        web_trans_id = transid_match.group(1) if transid_match else None
-
-        return session_id, web_user_id, web_trans_id
+    # Delegate to the canonical capture: it exchanges the code at the school root
+    # `/` (NOT /loginto.php, which returns a "session expired" page) and uses
+    # WEB_HEADERS — so the refresh path mints a session identically to the initial
+    # OAuth capture, and the scraper's UA matches.
+    cookies, info = await capture_web_session(schulnetz_base_url, code, state or "")
+    if not cookies:
+        return None, None, None
+    info = info or {}
+    return cookies.get("PHPSESSID"), info.get("id"), info.get("transid")
 

--- a/src/application/commands/refresh_token_command.py
+++ b/src/application/commands/refresh_token_command.py
@@ -72,67 +72,54 @@ class RefreshTokenHandler(ICommandHandler[RefreshTokenCommand, RefreshTokenRespo
                     ctx_kwargs["user_agent"] = command.user_agent
                 context = await browser.new_context(**ctx_kwargs)
 
-                host = urlparse(command.schulnetz_base_url).netloc
-                captured: dict[str, str | None] = {"code": None, "state": None}
-
-                async def _harvest_code(route):
-                    # Grab the OAuth code off the redirect to Schulnetz, then ABORT it.
-                    # Letting the browser load /?code= makes Schulnetz consume the
-                    # single-use code right there, leaving the later httpx exchange
-                    # with a spent code and a dead PHPSESSID. (Same trick as the
-                    # mobile-token flow in _exchange_mobile_tokens.)
-                    req_url = route.request.url
-                    if "code=" in req_url:
-                        qs = parse_qs(urlparse(req_url).query)
-                        captured["code"] = qs.get("code", [None])[0]
-                        captured["state"] = qs.get("state", [None])[0]
-                        await route.abort()
-                    else:
-                        await route.continue_()
-
                 page = await context.new_page()
-                await page.route(lambda u: host in u, _harvest_code)
-                code: str | None = None
-                state: str | None = None
 
                 try:
                     try:
                         await page.goto(command.schulnetz_base_url, wait_until="load", timeout=60_000)
                     except Exception:
-                        pass  # the post-SSO ?code= redirect is intercepted + aborted
+                        pass
 
                     # Expired MS SSO → need credentials to re-auth via Microsoft.
-                    if not captured["code"] and "login.microsoftonline.com" in page.url:
+                    if "login.microsoftonline.com" in page.url:
                         if not command.email or not command.password:
                             return RefreshTokenResponseDto(
                                 success=False,
                                 message="Microsoft SSO session expired. Re-authenticate via /api/authenticate/oauth/mobile/url.",
                             )
+                        await _perform_microsoft_sso(page, command.email, command.password)
                         try:
-                            await _perform_microsoft_sso(page, command.email, command.password)
+                            await page.wait_for_url(f"{command.schulnetz_base_url}*", timeout=30_000)
                         except Exception:
-                            pass  # final ?code= redirect is intercepted + aborted
+                            pass
 
-                    # Let the intercepted redirect settle.
-                    for _ in range(20):
-                        if captured["code"]:
-                            break
-                        await page.wait_for_timeout(500)
-
-                    code, state = captured["code"], captured["state"]
-                    if not code:
-                        return RefreshTokenResponseDto(success=False, message="Failed to obtain authorization code")
+                    # The browser completed the OAuth round-trip, so Schulnetz set a
+                    # valid PHPSESSID on it (bound to this context's UA). Harvest that
+                    # session straight from the browser — re-exchanging the now-spent
+                    # single-use OAuth code over httpx only yields a dead session.
+                    sn_cookies = await context.cookies(command.schulnetz_base_url)
+                    host = urlparse(command.schulnetz_base_url).netloc
+                    phps = [c for c in sn_cookies if c["name"] == "PHPSESSID"]
+                    # Schulnetz regenerates the session on login and sets it as a
+                    # host-only cookie (domain == host, no leading dot). Prefer that
+                    # over the stale, subdomain-wide ".host" cookie left from before.
+                    host_only = [c for c in phps if c.get("domain", "").lstrip(".") == host
+                                 and not c.get("domain", "").startswith(".")]
+                    session_id = (host_only or phps or [{"value": None}])[0]["value"]
+                    html = await page.content()
+                    id_m = re.search(r"[?&]id=([a-f0-9]{10,})", html)
+                    transid_m = re.search(r"[?&]transid=([a-f0-9]+)", html)
+                    web_user_id = id_m.group(1) if id_m else None
+                    web_trans_id = transid_m.group(1) if transid_m else None
+                    logger.info("refresh: harvested web session php=%s id=%s transid=%s", bool(session_id), web_user_id, web_trans_id)
+                    if not session_id:
+                        return RefreshTokenResponseDto(success=False, message="No web session captured after login")
 
                 finally:
                     await page.close()
 
                 # Mobile token exchange via a separate PKCE round-trip.
                 access_token, refresh_token = await _exchange_mobile_tokens(context, command.schulnetz_base_url)
-
-                # Capture web session cookies + landing-page params using the original code.
-                session_id, web_user_id, web_trans_id = await _capture_web_session(
-                    command.schulnetz_base_url, code, state
-                )
 
                 # Snapshot the updated context for the caller to persist.
                 updated_state = await context.storage_state()

--- a/src/application/queries/scrape_web_page_query.py
+++ b/src/application/queries/scrape_web_page_query.py
@@ -37,13 +37,18 @@ async def _scrape_all_semester_grades(
     """
     html = await scrape_page(base_url, cookies, "21311", session_id, transid, user_agent=user_agent)
     if html is None:
+        logger.warning("grades: initial Noten page load returned None (web session expired / redirect)")
         return None
 
     options = parse_semester_options(html)
     student = scrape_noten(html).student
+    logger.info("grades: %d semester options: %s", len(options),
+                [f"{lbl}{'*' if sel else ''}" for _, lbl, sel in options])
     if not options:
         # No switcher — just the single visible semester.
-        return scrape_noten(html)
+        page0 = scrape_noten(html)
+        logger.info("grades: no semester switcher; %d courses on the visible page", len(page0.courses))
+        return page0
 
     original = next((sid for sid, _, sel in options if sel), options[0][0])
     fresh = (m.group(1) if (m := _TRANSID_RE.search(html)) else None) or transid
@@ -67,6 +72,7 @@ async def _scrape_all_semester_grades(
         if m := _TRANSID_RE.search(page_html):
             fresh = m.group(1)
         page = scrape_noten(page_html)
+        logger.info("grades: sem %s (%s) -> %d courses", label, sem_id, len(page.courses))
         if page.courses:
             merged.extend(page.courses)
             empty = 0
@@ -79,6 +85,7 @@ async def _scrape_all_semester_grades(
 
     # Put the session back on the semester it started on.
     await save_semid(base_url, cookies, session_id, fresh, original, user_agent=user_agent)
+    logger.info("grades: merged %d courses across %d semesters", len(merged), len(options))
     return GradesPageDto(student=student, courses=merged)
 
 SCRAPERS = {

--- a/src/application/services/web_session_service.py
+++ b/src/application/services/web_session_service.py
@@ -136,8 +136,10 @@ async def scrape_page(schulnetz_base_url: str, cookies: dict[str, str], pageid: 
         "Referer": f"{schulnetz_base_url}/",
         "Sec-Fetch-Site": "same-origin",
     }
-    if user_agent:
-        headers["User-Agent"] = user_agent
+    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
+    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
+    # one. Replaying with a different (per-account) UA gets the session rejected.
+    _ = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=30.0) as client:
         try:
@@ -188,8 +190,10 @@ async def download_file(
         "Referer": f"{schulnetz_base_url}/",
         "Sec-Fetch-Site": "same-origin",
     }
-    if user_agent:
-        headers["User-Agent"] = user_agent
+    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
+    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
+    # one. Replaying with a different (per-account) UA gets the session rejected.
+    _ = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=60.0) as client:
         try:
@@ -265,8 +269,10 @@ async def fetch_scheduler_data(schulnetz_base_url: str, cookies: dict[str, str],
         "Accept": "text/html, */*; q=0.01",
         "X-Requested-With": "XMLHttpRequest",
     }
-    if user_agent:
-        headers["User-Agent"] = user_agent
+    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
+    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
+    # one. Replaying with a different (per-account) UA gets the session rejected.
+    _ = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=30.0) as client:
         try:
@@ -319,8 +325,10 @@ async def save_semid(
         "X-Requested-With": "XMLHttpRequest",
         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
     }
-    if user_agent:
-        headers["User-Agent"] = user_agent
+    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
+    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
+    # one. Replaying with a different (per-account) UA gets the session rejected.
+    _ = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=30.0) as client:
         try:

--- a/src/application/services/web_session_service.py
+++ b/src/application/services/web_session_service.py
@@ -136,10 +136,11 @@ async def scrape_page(schulnetz_base_url: str, cookies: dict[str, str], pageid: 
         "Referer": f"{schulnetz_base_url}/",
         "Sec-Fetch-Site": "same-origin",
     }
-    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
-    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
-    # one. Replaying with a different (per-account) UA gets the session rejected.
-    _ = user_agent
+    # Schulnetz binds the PHPSESSID to the UA that created it. The refresh runner
+    # mints the session in a browser using the account UA, so the scrape must
+    # replay that same UA — otherwise the session is rejected.
+    if user_agent:
+        headers["User-Agent"] = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=30.0) as client:
         try:
@@ -190,10 +191,11 @@ async def download_file(
         "Referer": f"{schulnetz_base_url}/",
         "Sec-Fetch-Site": "same-origin",
     }
-    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
-    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
-    # one. Replaying with a different (per-account) UA gets the session rejected.
-    _ = user_agent
+    # Schulnetz binds the PHPSESSID to the UA that created it. The refresh runner
+    # mints the session in a browser using the account UA, so the scrape must
+    # replay that same UA — otherwise the session is rejected.
+    if user_agent:
+        headers["User-Agent"] = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=60.0) as client:
         try:
@@ -269,10 +271,11 @@ async def fetch_scheduler_data(schulnetz_base_url: str, cookies: dict[str, str],
         "Accept": "text/html, */*; q=0.01",
         "X-Requested-With": "XMLHttpRequest",
     }
-    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
-    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
-    # one. Replaying with a different (per-account) UA gets the session rejected.
-    _ = user_agent
+    # Schulnetz binds the PHPSESSID to the UA that created it. The refresh runner
+    # mints the session in a browser using the account UA, so the scrape must
+    # replay that same UA — otherwise the session is rejected.
+    if user_agent:
+        headers["User-Agent"] = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=30.0) as client:
         try:
@@ -325,10 +328,11 @@ async def save_semid(
         "X-Requested-With": "XMLHttpRequest",
         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
     }
-    # Keep WEB_HEADERS' User-Agent: Schulnetz binds the PHPSESSID to the UA that
-    # created it (server-side, via WEB_HEADERS), so the scrape must use the same
-    # one. Replaying with a different (per-account) UA gets the session rejected.
-    _ = user_agent
+    # Schulnetz binds the PHPSESSID to the UA that created it. The refresh runner
+    # mints the session in a browser using the account UA, so the scrape must
+    # replay that same UA — otherwise the session is rejected.
+    if user_agent:
+        headers["User-Agent"] = user_agent
 
     async with httpx.AsyncClient(headers=headers, cookies=cookies, follow_redirects=True, timeout=30.0) as client:
         try:


### PR DESCRIPTION
Fixed the refresh runner minting a dead web session

Closes #143

The refresh runner produced a PHPSESSID that every scrape rejected ("Session expired / IP rejected"). Root causes, all fixed:

1. **Re-exchanged a spent code.** The browser loads `/?code=` (consuming the single-use code) and Schulnetz logs it in right there. We now **harvest the browser session directly** instead of re-POSTing the dead code over httpx.
2. **Wrong PHPSESSID.** Schulnetz regenerates the session on login and sets it host-only (`schulnetz.host`); we were grabbing the stale subdomain-wide (`.schulnetz.host`) cookie. Now prefer the host-only one.
3. **UA mismatch.** The session is minted in a browser using the account UA, so the scrape must replay that same UA (reverted the WEB_HEADERS override on the scrape path).

Also: delegate the (now-unused) loginto.php capture to the canonical root-`/` capture, and per-semester scrape logging.

**Verified end-to-end against live Schulnetz:** refresh → scrape returns 179 courses / 35 exams across 60 semesters; a full plugin sync wrote 5 new grades.