### PR TITLE
Default Schulnetz client id + web base URL as constants

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,8 +14,10 @@ SchulwareAPI is a unified FastAPI application that provides access to Schulnetz 
 
 ### Environment Setup
 - Copy `.env.example` to `.env` and configure:
-  - `SCHULNETZ_WEB_BASE_URL`: Base URL for web scraping (PWA host)
-  - `SCHULNETZ_CLIENT_ID`: Client ID for API access
+  - `SCHULNETZ_WEB_BASE_URL`: PWA host for web scraping. **Optional** — defaults to
+    the public host (`src/application/constants.py`); set only to override.
+  - `SCHULNETZ_CLIENT_ID`: Schulnetz mobile client id. **Optional** — defaults to the
+    public id (`src/application/constants.py`); set only to override.
   - `SENTRY_DSN`: (Optional) GlitchTip Data Source Name for error reporting
 - The per-school API base URL is **not** configured here. Clients pass it
   per-request via the `X-Schulnetz-Base-Url` header (or the `schulnetz_base_url`

--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,14 @@
 # Copy this file to .env and fill in your actual values
 
 # Schulnetz API Configuration
+# Both default to the public Schulnetz mobile client id + PWA host baked into the
+# app, so they are OPTIONAL — uncomment and set only to override for a non-standard
+# Schulnetz deployment.
 # Note: the school API base URL is no longer configured here. Clients must send
 # it per-request via the `X-Schulnetz-Base-Url` HTTP header (or the
 # `schulnetz_base_url` body field for /api/authenticate/refresh).
-SCHULNETZ_WEB_BASE_URL=https://schulnetz.web.app
-SCHULNETZ_CLIENT_ID=your_client_id_here
+# SCHULNETZ_WEB_BASE_URL=https://schulnetz.web.app
+# SCHULNETZ_CLIENT_ID=ppyybShnMerHdtBQ
 
 # Sentry/GlitchTip Error Tracking Configuration (Optional)
 # SENTRY_DSN=https://your_dsn@glitchtip.example.com/project_id

--- a/src/api/auth/auth.py
+++ b/src/api/auth/auth.py
@@ -18,16 +18,15 @@ import httpx
 from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 
+from src.application.constants import DEFAULT_SCHULNETZ_CLIENT_ID
 from src.infrastructure.logging_config import get_logger
 
 logger = get_logger("authentication")
 
 load_dotenv()
 
-SCHULNETZ_CLIENT_ID = os.getenv("SCHULNETZ_CLIENT_ID")
-
-if not all([SCHULNETZ_CLIENT_ID]):
-    raise EnvironmentError("Missing required environment variables.")
+# Public, instance-invariant default; override via env only for a non-standard deployment.
+SCHULNETZ_CLIENT_ID = os.getenv("SCHULNETZ_CLIENT_ID", DEFAULT_SCHULNETZ_CLIENT_ID)
 
 
 def generate_random_string(length: int) -> str:

--- a/src/application/constants.py
+++ b/src/application/constants.py
@@ -1,0 +1,11 @@
+"""Public Schulnetz constants.
+
+The mobile client id and the PWA host are identical across every Schulnetz
+instance (the per-school API base URL is supplied per request, not here) and
+neither is a secret, so they ship as defaults — SchulwareAPI runs with no
+Schulnetz env configured. Set the matching environment variable only to override
+for a non-standard deployment.
+"""
+
+DEFAULT_SCHULNETZ_CLIENT_ID = "ppyybShnMerHdtBQ"
+DEFAULT_SCHULNETZ_WEB_BASE_URL = "https://schulnetz.web.app"

--- a/src/application/services/env_service.py
+++ b/src/application/services/env_service.py
@@ -4,8 +4,8 @@ from dotenv import load_dotenv
 def load_env():
     load_dotenv()
 
-def get_env_variable(var_name: str) -> str:
-    value = os.environ.get(var_name)
+def get_env_variable(var_name: str, default: str | None = None) -> str:
+    value = os.environ.get(var_name, default)
     if value is None:
         raise EnvironmentError(f"Required environment variable '{var_name}' is not set.")
     return value

--- a/src/application/services/schulnetz_mobile_service.py
+++ b/src/application/services/schulnetz_mobile_service.py
@@ -1,5 +1,6 @@
 import httpx
 from typing import Any
+from src.application.constants import DEFAULT_SCHULNETZ_CLIENT_ID
 from src.application.services.env_service import get_env_variable
 from src.application.services.token_service import token_service, ApplicationType
 from src.application.services.test_token_config import is_test_token, get_mock_data
@@ -11,7 +12,7 @@ logger = get_logger("mobile_api")
 class SchulnetzMobileService:
     def __init__(self):
         self.base_url = get_env_variable("SCHULNETZ_API_BASE_URL")
-        self.client_id = get_env_variable("SCHULNETZ_CLIENT_ID")
+        self.client_id = get_env_variable("SCHULNETZ_CLIENT_ID", DEFAULT_SCHULNETZ_CLIENT_ID)
     
     async def get_user_info(self, user_id: str, token: str | None = None) -> Dict | None:
         """Get user information from mobile API"""

--- a/src/application/services/schulnetz_web_service.py
+++ b/src/application/services/schulnetz_web_service.py
@@ -2,6 +2,7 @@ import httpx
 from typing import Any
 from src.infrastructure.logging_config import get_logger
 from src.infrastructure.monitoring import monitor_performance, add_breadcrumb, capture_exception
+from src.application.constants import DEFAULT_SCHULNETZ_CLIENT_ID, DEFAULT_SCHULNETZ_WEB_BASE_URL
 from src.application.services.env_service import get_env_variable
 from src.application.services.token_service import token_service, ApplicationType
 from src.application.services.test_token_config import is_test_token, get_mock_data
@@ -11,8 +12,8 @@ logger = get_logger("web_scraper")
 
 class SchulnetzWebService:
     def __init__(self):
-        self.base_url = get_env_variable("SCHULNETZ_WEB_BASE_URL")
-        self.client_id = get_env_variable("SCHULNETZ_CLIENT_ID")
+        self.base_url = get_env_variable("SCHULNETZ_WEB_BASE_URL", DEFAULT_SCHULNETZ_WEB_BASE_URL)
+        self.client_id = get_env_variable("SCHULNETZ_CLIENT_ID", DEFAULT_SCHULNETZ_CLIENT_ID)
     
     def _get_web_session_cookies(self, user_id: str) -> dict[str, str]:
         """Get web session cookies from stored session data"""

--- a/src/application/services/token_service.py
+++ b/src/application/services/token_service.py
@@ -1,6 +1,7 @@
 
 import httpx
 from src.infrastructure.logging_config import get_logger
+from src.application.constants import DEFAULT_SCHULNETZ_CLIENT_ID
 from src.application.services.env_service import get_env_variable
 
 # Logger for this module
@@ -12,7 +13,7 @@ class ApplicationType:
 
 class TokenService:
     def __init__(self):
-        self.client_id = get_env_variable("SCHULNETZ_CLIENT_ID")
+        self.client_id = get_env_variable("SCHULNETZ_CLIENT_ID", DEFAULT_SCHULNETZ_CLIENT_ID)
 
     async def refresh_mobile_token(self, refresh_token: str) -> tuple[str | None, str | None]:
         """Refresh mobile API token"""


### PR DESCRIPTION
`SCHULNETZ_CLIENT_ID` and `SCHULNETZ_WEB_BASE_URL` are public, instance-invariant values (the per-school API base URL is supplied per request, not here), so they don't need to be configured. They now ship as defaults in `src/application/constants.py`:

- `get_env_variable` gains an optional `default`.
- `auth.py`, `token_service`, `schulnetz_mobile_service`, `schulnetz_web_service` read them with the constant as the fallback.
- `auth.py` no longer raises `EnvironmentError` at import when the client id is unset.
- The env vars remain **optional overrides**; `.env.example` + CLAUDE.md updated.

Validated: all touched files compile; with both env vars unset the defaults apply, an explicit env value still overrides, and `get_env_variable` without a default still raises (unchanged for other required vars).