### PR TITLE
Validated caller-supplied base URLs to block SSRF

### DIFF
--- a/src/api/controllers/auth_controller.py
+++ b/src/api/controllers/auth_controller.py
@@ -4,6 +4,7 @@ from mediatorx import Mediator
 from src.api.controller import controller
 from src.api.dependencies import get_mediator
 from src.api.rate_limit import shared_limiter
+from src.api.url_guard import validate_base_url
 from src.application.commands.refresh_token_command import LoginCommand
 from src.application.dtos.refresh_dtos import LoginRequestDto, LoginResponseDto
 
@@ -28,7 +29,7 @@ class AuthController:
         rotated `session_cookies` to persist for the next call.
         """
         return await self.mediator.send(LoginCommand(
-            schulnetz_base_url=body.schulnetz_base_url,
+            schulnetz_base_url=validate_base_url(body.schulnetz_base_url),
             session_cookies=body.session_cookies,
             email=body.email,
             password=body.password,

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -8,6 +8,8 @@ and dispatch via `mediator.send(...)`.
 from fastapi import Header, HTTPException
 from mediatorx import Mediator
 
+from src.api.url_guard import validate_base_url
+
 from src.application.commands.refresh_token_command import (
     LoginCommand,
     LoginHandler,
@@ -69,4 +71,4 @@ def get_schulnetz_base_url(
             status_code=400,
             detail="Missing required header 'X-Schulnetz-Base-Url'.",
         )
-    return x_schulnetz_base_url.rstrip("/")
+    return validate_base_url(x_schulnetz_base_url)

--- a/src/api/url_guard.py
+++ b/src/api/url_guard.py
@@ -1,0 +1,46 @@
+"""SSRF guard for caller-supplied Schulnetz base URLs.
+
+Callers pass the target Schulnetz instance per request (header or login body) and
+the server then fetches it, so an unvalidated value lets a caller point the server
+at internal targets (cloud metadata, loopback, RFC1918). This keeps the proxy to
+public http/https hosts only.
+"""
+
+import ipaddress
+from urllib.parse import urlparse
+
+from fastapi import HTTPException
+
+
+def is_safe_base_url(url: str) -> bool:
+    """True if ``url`` is http/https to a public host - not loopback, link-local,
+    cloud-metadata, or a private/reserved address. Public host names are allowed
+    (DNS rebinding is out of scope here)."""
+    if not url:
+        return False
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    host = parsed.hostname
+    if not host or host.lower() == "localhost":
+        return False
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return True
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def validate_base_url(url: str | None) -> str:
+    """Returns the trimmed URL, or raises 400 if it is missing or a disallowed target."""
+    trimmed = (url or "").rstrip("/")
+    if not is_safe_base_url(trimmed):
+        raise HTTPException(status_code=400, detail="Invalid or disallowed Schulnetz base URL.")
+    return trimmed


### PR DESCRIPTION
Validate the Schulnetz base URL at both ingress points (the X-Schulnetz-Base-Url header dependency and the /api/authenticate/login body): only http/https to a public host is allowed, rejecting localhost and loopback/link-local/private/reserved IPs so the server cannot be pointed at cloud metadata or internal services.

Closes #153