### PR TITLE
Stopped capturing args/kwargs in Sentry monitor_performance

### DIFF
--- a/src/infrastructure/monitoring.py
+++ b/src/infrastructure/monitoring.py
@@ -284,8 +284,6 @@ def monitor_performance(operation: str):
                         context={
                             "operation": operation,
                             "function": func.__name__,
-                            "args": str(args)[:200],
-                            "kwargs": str(kwargs)[:200]
                         }
                     )
                     raise
@@ -312,8 +310,6 @@ def monitor_performance(operation: str):
                         context={
                             "operation": operation,
                             "function": func.__name__,
-                            "args": str(args)[:200],
-                            "kwargs": str(kwargs)[:200]
                         }
                     )
                     raise


### PR DESCRIPTION
monitor_performance serialized raw args/kwargs into the Sentry exception context, which could include the bearer token, password, or TOTP secret. Dropped the args/kwargs capture; operation + function name remain.

Closes #154