### PR TITLE
Reused the shared HTTPBearer and removed the unused test-token helper

### DIFF
--- a/src/api/auth/token_dependency.py
+++ b/src/api/auth/token_dependency.py
@@ -1,22 +1,16 @@
 from fastapi import Depends, HTTPException
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from src.application.services.test_token_config import is_test_token
+from fastapi.security import HTTPAuthorizationCredentials
 
-security = HTTPBearer()
+from src.api.auth.bearer import security
+
 
 def get_current_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
     """
-    Extract and validate bearer token from request headers.
+    Extract the bearer token from the request headers.
 
-    Supports both real OAuth2 tokens and test tokens for development.
-    Test token: "test-token-12345" returns dummy data for all endpoints.
+    The token is the caller's upstream Schulnetz mobile token, replayed downstream
+    (SchulwareAPI is a stateless proxy and issues no tokens of its own).
     """
     if credentials:
-        token = credentials.credentials
-        # Accept both real tokens and test tokens
-        return token
+        return credentials.credentials
     raise HTTPException(status_code=403, detail="Invalid or missing token")
-
-def is_test_token_request(token: str) -> bool:
-    """Check if the request is using a test token"""
-    return is_test_token(token)


### PR DESCRIPTION
token_dependency now imports the single shared HTTPBearer from bearer.py instead of constructing its own, and the unused is_test_token_request wrapper is removed.

Closes #155